### PR TITLE
Fix: agency passwords double-hashed in admin panel (lockout bug)

### DIFF
--- a/app/Filament/Resources/AgencyResource.php
+++ b/app/Filament/Resources/AgencyResource.php
@@ -24,7 +24,8 @@ class AgencyResource extends Resource
             Forms\Components\TextInput::make('phone')->maxLength(50),
             Forms\Components\TextInput::make('password')
                 ->password()
-                ->dehydrateStateUsing(fn ($state) => filled($state) ? bcrypt($state) : null)
+                // Agency::setPasswordAttribute() already hashes on save - hashing
+                // here too would double-hash and lock the agency out.
                 ->dehydrated(fn ($state) => filled($state)) // only save if provided
                 ->maxLength(255),
         ]);


### PR DESCRIPTION
## Summary
- `AgencyResource`'s password field called `bcrypt($state)` before dehydrating, but `Agency::setPasswordAttribute()` already hashes on save (see `app/Models/Agency.php`). Every password set or changed for an agency through the admin panel was silently double-hashed, permanently locking that agency out of the agency panel.
- Fix: remove the redundant `bcrypt()` call and let the model's own mutator do the hashing (same one-hash pattern already used correctly everywhere else, e.g. `AuthController::register`).

## Test plan
- [x] Reproduced empirically before the fix: set a password via `/admin/agencies/{id}/edit`, confirmed `Hash::check($password, $agency->password)` returned false (double-hashed).
- [x] After the fix: same flow, `Hash::check()` now returns true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)