### PR TITLE
Agency panel: self-service profile page

### DIFF
--- a/app/Filament/Agency/Pages/EditProfile.php
+++ b/app/Filament/Agency/Pages/EditProfile.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Filament\Agency\Pages;
+
+use Filament\Forms\Components\Component;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
+use Filament\Pages\Auth\EditProfile as BaseEditProfile;
+use Illuminate\Validation\Rules\Password;
+
+class EditProfile extends BaseEditProfile
+{
+    public function form(Form $form): Form
+    {
+        return $form->schema([
+            $this->getNameFormComponent(),
+            $this->getEmailFormComponent(),
+            $this->getPhoneFormComponent(),
+            $this->getPasswordFormComponent(),
+            $this->getPasswordConfirmationFormComponent(),
+        ]);
+    }
+
+    protected function getPhoneFormComponent(): Component
+    {
+        return TextInput::make('phone')
+            ->tel()
+            ->maxLength(50);
+    }
+
+    /**
+     * Agency::setPasswordAttribute() already hashes on save - the base
+     * implementation also calls Hash::make(), which would double-hash
+     * and lock the agency out. Same class of bug as the admin panel's
+     * AgencyResource; dehydrate the plain value here instead.
+     */
+    protected function getPasswordFormComponent(): Component
+    {
+        return TextInput::make('password')
+            ->label(__('filament-panels::pages/auth/edit-profile.form.password.label'))
+            ->password()
+            ->revealable(filament()->arePasswordsRevealable())
+            ->rule(Password::default())
+            ->autocomplete('new-password')
+            ->dehydrated(fn ($state) => filled($state))
+            ->live(debounce: 500)
+            ->same('passwordConfirmation');
+    }
+}

--- a/app/Providers/Filament/AgencyPanelProvider.php
+++ b/app/Providers/Filament/AgencyPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Agency\Pages\EditProfile;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -28,6 +29,7 @@ class AgencyPanelProvider extends PanelProvider
             ->path('agency')
             ->brandName('My Property Status - Agency')
             ->login()
+            ->profile(EditProfile::class)
             ->authGuard('agency')
             ->colors([
                 'primary' => '#2563eb',


### PR DESCRIPTION
## Summary
- Registers Filament's built-in `Pages\Auth\EditProfile` for the agency panel (`->profile()` in `AgencyPanelProvider`), giving agencies a way to edit their own name/email/phone and change their password from the user menu at `agency/profile`.
- Related to #7: the base `EditProfile::getPasswordFormComponent()` hashes with `Hash::make()` before saving, but `Agency::setPasswordAttribute()` already hashes on save - the exact same double-hashing bug just fixed in the admin panel's `AgencyResource`. Overrides the password field here to dehydrate the plain value instead, so the model's mutator hashes it exactly once.
- Independent of #7 (different files, no merge conflict) but same underlying root cause - worth reviewing together.

## Test plan
- [x] Verified live: profile page loads pre-filled with the logged-in agency's own name/email/phone, editing and saving works, password field correctly hashes once (`Hash::check()` confirmed directly against the DB).
- [x] Full round-trip: changed the password through the page, logged out, logged back in with the *new* password successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)