### PR TITLE
Fix: user passwords double-hashed in admin panel (lockout bug)

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -27,7 +27,8 @@ class UserResource extends Resource
             Forms\Components\TextInput::make('phone')->maxLength(50),
             Forms\Components\TextInput::make('password')
                 ->password()
-                ->dehydrateStateUsing(fn ($state) => filled($state) ? bcrypt($state) : null)
+                // User's 'password' => 'hashed' cast already hashes on save - hashing
+                // here too would double-hash and lock the user out.
                 ->dehydrated(fn ($state) => filled($state)) // only save if provided
                 ->maxLength(255),
         ]);


### PR DESCRIPTION
## Summary
Third occurrence of the same bug pattern already fixed for Agency (admin `AgencyResource` in #7, agency profile page in #8): `UserResource`'s password field called `bcrypt()` before dehydrating, but `User` already has `'password' => 'hashed'` in its casts. Any password set or changed for a user through the admin panel was silently double-hashed, locking that user out.

## Test plan
- [x] Set a password via `/admin/users/{id}/edit`, confirmed `Hash::check()` against it directly.
- [x] Full round-trip: logged in via the real `/api/login` endpoint with the new password to confirm the whole flow actually works, not just the hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)