### PR TITLE
Admin panel: flesh out PropertyResource

### DIFF
--- a/app/Filament/Resources/PropertyResource.php
+++ b/app/Filament/Resources/PropertyResource.php
@@ -1,43 +1,127 @@
 <?php
+
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\PropertyResource\Pages;
+use App\Filament\Resources\PropertyResource\RelationManagers;
 use App\Models\Property;
 use Filament\Forms;
-use Filament\Tables;
+use Filament\Forms\Form;
 use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
 
 class PropertyResource extends Resource
 {
     protected static ?string $model = Property::class;
+
     protected static ?string $navigationIcon = 'heroicon-o-home';
+
     protected static ?string $navigationGroup = 'Properties';
 
-    public static function form(Forms\Form $form): Forms\Form
+    public static function form(Form $form): Form
     {
-        return $form
-            ->schema([
-                Forms\Components\TextInput::make('title')->required(),
-                Forms\Components\Textarea::make('description'),
-                Forms\Components\TextInput::make('price')
-                    ->numeric()
-                    ->required(),
-            ]);
+        return $form->schema([
+            Forms\Components\Select::make('user_id')
+                ->label('Owner')
+                ->relationship('user', 'name')
+                ->searchable()
+                ->required(),
+            Forms\Components\TextInput::make('title')
+                ->required()
+                ->maxLength(255),
+            Forms\Components\Textarea::make('description')
+                ->columnSpanFull(),
+            Forms\Components\Select::make('type')
+                ->options([
+                    'apartment' => 'Apartment',
+                    'house' => 'House',
+                    'land' => 'Land',
+                    'commercial' => 'Commercial',
+                ]),
+            Forms\Components\Select::make('status')
+                ->options([
+                    'draft' => 'Draft',
+                    'published' => 'Published',
+                    'archived' => 'Archived',
+                ])
+                ->default('draft')
+                ->required(),
+            Forms\Components\TextInput::make('currency')
+                ->default('PKR')
+                ->maxLength(10),
+            Forms\Components\TextInput::make('price')
+                ->numeric(),
+            Forms\Components\TextInput::make('location')
+                ->maxLength(255),
+            Forms\Components\KeyValue::make('details')
+                ->label('Details (bedrooms, area, amenities, etc.)')
+                ->columnSpanFull(),
+        ]);
     }
 
-    public static function table(Tables\Table $table): Tables\Table
+    public static function table(Table $table): Table
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('title')->searchable()->sortable(),
-                Tables\Columns\TextColumn::make('price')->sortable(),
-                Tables\Columns\TextColumn::make('created_at')->dateTime(),
+                Tables\Columns\TextColumn::make('title')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('Owner')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('type')
+                    ->badge()
+                    ->placeholder('—'),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (?string $state) => match ($state) {
+                        'draft' => 'gray',
+                        'published' => 'success',
+                        'archived' => 'danger',
+                        default => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('price')
+                    ->money(fn ($record) => $record->currency ?? 'PKR')
+                    ->sortable()
+                    ->placeholder('—'),
+                Tables\Columns\TextColumn::make('location')
+                    ->searchable()
+                    ->placeholder('—'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
             ])
-            ->filters([])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')->options([
+                    'draft' => 'Draft',
+                    'published' => 'Published',
+                    'archived' => 'Archived',
+                ]),
+                Tables\Filters\SelectFilter::make('type')->options([
+                    'apartment' => 'Apartment',
+                    'house' => 'House',
+                    'land' => 'Land',
+                    'commercial' => 'Commercial',
+                ]),
+            ])
             ->actions([
                 Tables\Actions\EditAction::make(),
                 Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
             ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            RelationManagers\ListingsRelationManager::class,
+            RelationManagers\MediaRelationManager::class,
+        ];
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/PropertyResource/RelationManagers/ListingsRelationManager.php
+++ b/app/Filament/Resources/PropertyResource/RelationManagers/ListingsRelationManager.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Filament\Resources\PropertyResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class ListingsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'listings';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('agency.name')
+                    ->label('Agency'),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state) => match ($state) {
+                        'pending' => 'warning',
+                        'available' => 'success',
+                        'rented', 'sold' => 'info',
+                        'archived' => 'gray',
+                        default => 'gray',
+                    }),
+                Tables\Columns\IconColumn::make('user_approved')
+                    ->label('Owner Approved')
+                    ->boolean(),
+                Tables\Columns\TextColumn::make('agency_notes')
+                    ->label('Notes')
+                    ->placeholder('—')
+                    ->limit(40),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/PropertyResource/RelationManagers/MediaRelationManager.php
+++ b/app/Filament/Resources/PropertyResource/RelationManagers/MediaRelationManager.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Filament\Resources\PropertyResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\Storage;
+
+class MediaRelationManager extends RelationManager
+{
+    protected static string $relationship = 'media';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\ImageColumn::make('path')
+                    ->label('Preview')
+                    ->disk('public')
+                    ->height(60),
+                Tables\Columns\TextColumn::make('type')
+                    ->placeholder('—'),
+                Tables\Columns\TextColumn::make('caption')
+                    ->placeholder('—'),
+                Tables\Columns\TextColumn::make('sort_order')
+                    ->label('Order')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->defaultSort('sort_order')
+            ->actions([
+                Tables\Actions\DeleteAction::make()
+                    ->after(function ($record) {
+                        Storage::disk('public')->delete($record->path);
+                    }),
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
The admin `PropertyResource` form previously only had `title`/`description`/`price` - no owner visibility, no `type`/`location`/`status`/`currency`/`details`, and no way to see a property's listings or media without querying the database directly.

- Full field set from the `properties` table, plus an owner select (searchable, so an admin can look up or reassign a property's user)
- `status`/`type` as proper selects with badge coloring in the table; filters for both
- `ListingsRelationManager` - read-only oversight of which agencies have listed this property and whether the owner has approved (a full cross-agency admin `ListingResource` is separate future work; this is scoped to what's visible from a single property)
- `MediaRelationManager` - with delete (including removing the actual file from the `public` disk), for content moderation

## Test plan
- [x] Edit form loads and saves all fields correctly (owner select, type/status selects, currency/price/location, details KeyValue)
- [x] List view shows owner name, badge-colored status/type, filters work
- [x] Listings tab shows real data (agency name, status badge, approval icon)
- [x] Media tab: uploaded a real image via the API, confirmed it renders correctly in the Preview column (`naturalWidth` matches the actual file, not a broken image); the two seeded `via.placeholder.com` rows fail to load only because this sandbox has no external network access, not because of the code
- [x] Media delete removes both the DB row and the actual file from disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)