### PR TITLE
Admin panel: SupportTicketResource

### DIFF
--- a/app/Filament/Resources/SupportTicketResource.php
+++ b/app/Filament/Resources/SupportTicketResource.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\SupportTicketResource\Pages;
+use App\Models\SupportTicket;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class SupportTicketResource extends Resource
+{
+    protected static ?string $model = SupportTicket::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-lifebuoy';
+
+    protected static ?string $navigationBadgeTooltip = 'Open tickets';
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) static::getModel()::where('status', 'open')->count();
+    }
+
+    public static function getNavigationBadgeColor(): string|array|null
+    {
+        return static::getModel()::where('status', 'open')->exists() ? 'danger' : null;
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Select::make('user_id')
+                ->label('Submitted by')
+                ->relationship('user', 'name')
+                ->searchable()
+                ->required()
+                ->visible(fn (string $operation): bool => $operation === 'create'),
+            Forms\Components\Placeholder::make('submitted_by')
+                ->label('Submitted by')
+                ->content(fn (?SupportTicket $record) => $record?->user
+                    ? "{$record->user->name} ({$record->user->email})"
+                    : '—')
+                ->visible(fn (string $operation): bool => $operation === 'edit'),
+            Forms\Components\TextInput::make('subject')
+                ->required()
+                ->maxLength(255)
+                ->disabled(fn (string $operation): bool => $operation === 'edit'),
+            Forms\Components\Textarea::make('message')
+                ->required()
+                ->columnSpanFull()
+                ->disabled(fn (string $operation): bool => $operation === 'edit'),
+            Forms\Components\Select::make('status')
+                ->options([
+                    'open' => 'Open',
+                    'in_progress' => 'In Progress',
+                    'resolved' => 'Resolved',
+                    'closed' => 'Closed',
+                ])
+                ->default('open')
+                ->required(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('subject')
+                    ->searchable()
+                    ->limit(50),
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('Submitted by')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state) => match ($state) {
+                        'open' => 'danger',
+                        'in_progress' => 'warning',
+                        'resolved' => 'success',
+                        'closed' => 'gray',
+                        default => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Submitted')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')->options([
+                    'open' => 'Open',
+                    'in_progress' => 'In Progress',
+                    'resolved' => 'Resolved',
+                    'closed' => 'Closed',
+                ]),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListSupportTickets::route('/'),
+            'create' => Pages\CreateSupportTicket::route('/create'),
+            'edit' => Pages\EditSupportTicket::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/SupportTicketResource/Pages/CreateSupportTicket.php
+++ b/app/Filament/Resources/SupportTicketResource/Pages/CreateSupportTicket.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\SupportTicketResource\Pages;
+
+use App\Filament\Resources\SupportTicketResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateSupportTicket extends CreateRecord
+{
+    protected static string $resource = SupportTicketResource::class;
+}

--- a/app/Filament/Resources/SupportTicketResource/Pages/EditSupportTicket.php
+++ b/app/Filament/Resources/SupportTicketResource/Pages/EditSupportTicket.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\SupportTicketResource\Pages;
+
+use App\Filament\Resources\SupportTicketResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditSupportTicket extends EditRecord
+{
+    protected static string $resource = SupportTicketResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/SupportTicketResource/Pages/ListSupportTickets.php
+++ b/app/Filament/Resources/SupportTicketResource/Pages/ListSupportTickets.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\SupportTicketResource\Pages;
+
+use App\Filament\Resources\SupportTicketResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListSupportTickets extends ListRecords
+{
+    protected static string $resource = SupportTicketResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
Support tickets created via `/api/support-tickets` previously had zero visibility anywhere in either panel - they just sat in the database.

- List: subject, submitter, status badge (`open`=danger through `closed`=gray), newest-first, filterable by status.
- Navigation badge shows the open-ticket count, red when non-zero, as an at-a-glance "needs attention" signal.
- Edit: `subject`/`message` are shown but `disabled()` (so not dehydrated) - admin sees exactly what the user submitted without being able to silently rewrite it. `status` is the one editable field, which is the real moderation action available given the schema has no reply/comment mechanism (there's no thread/reply table - just `status`).
- Create: lets an admin log a ticket on a user's behalf (e.g. a phone-support case) via a searchable "Submitted by" select.

## Test plan
- [x] List renders correctly, including a ticket I created earlier via the API in this session
- [x] Edit: submitted-by placeholder shows correctly, subject/message render but are visually disabled, changed status to `resolved` and confirmed via direct DB check the status updated **and** the subject stayed byte-for-byte unchanged (disabled field wasn't dehydrated)
- [x] Navigation badge count dropped from 11 to 10 after resolving one ticket, badge color is red
- [x] Status filter via query string shows exactly the matching ticket
- [ ] **Known gap**: could not get automated browser typing to trigger the live search on the Create page's "Submitted by" field (Filament's `Select::relationship()->searchable()`) in this session's sandbox - confirmed via network inspection that no Livewire request fires and the underlying `<select>` never receives options, with zero JS console errors. This is a first-party Filament component already used identically (and verified working for *displaying* a pre-filled value) in `PropertyResource`'s owner field from #12, so I'm treating this as a browser-automation limitation rather than a code defect, but flagging it since I wasn't able to prove the Create flow's user-picker interaction end-to-end live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)