### PR TITLE
Sync develop into main

### DIFF
--- a/app/Filament/Resources/PropertyResource.php
+++ b/app/Filament/Resources/PropertyResource.php
@@ -1,43 +1,127 @@
 <?php
+
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\PropertyResource\Pages;
+use App\Filament\Resources\PropertyResource\RelationManagers;
 use App\Models\Property;
 use Filament\Forms;
-use Filament\Tables;
+use Filament\Forms\Form;
 use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
 
 class PropertyResource extends Resource
 {
     protected static ?string $model = Property::class;
+
     protected static ?string $navigationIcon = 'heroicon-o-home';
+
     protected static ?string $navigationGroup = 'Properties';
 
-    public static function form(Forms\Form $form): Forms\Form
+    public static function form(Form $form): Form
     {
-        return $form
-            ->schema([
-                Forms\Components\TextInput::make('title')->required(),
-                Forms\Components\Textarea::make('description'),
-                Forms\Components\TextInput::make('price')
-                    ->numeric()
-                    ->required(),
-            ]);
+        return $form->schema([
+            Forms\Components\Select::make('user_id')
+                ->label('Owner')
+                ->relationship('user', 'name')
+                ->searchable()
+                ->required(),
+            Forms\Components\TextInput::make('title')
+                ->required()
+                ->maxLength(255),
+            Forms\Components\Textarea::make('description')
+                ->columnSpanFull(),
+            Forms\Components\Select::make('type')
+                ->options([
+                    'apartment' => 'Apartment',
+                    'house' => 'House',
+                    'land' => 'Land',
+                    'commercial' => 'Commercial',
+                ]),
+            Forms\Components\Select::make('status')
+                ->options([
+                    'draft' => 'Draft',
+                    'published' => 'Published',
+                    'archived' => 'Archived',
+                ])
+                ->default('draft')
+                ->required(),
+            Forms\Components\TextInput::make('currency')
+                ->default('PKR')
+                ->maxLength(10),
+            Forms\Components\TextInput::make('price')
+                ->numeric(),
+            Forms\Components\TextInput::make('location')
+                ->maxLength(255),
+            Forms\Components\KeyValue::make('details')
+                ->label('Details (bedrooms, area, amenities, etc.)')
+                ->columnSpanFull(),
+        ]);
     }
 
-    public static function table(Tables\Table $table): Tables\Table
+    public static function table(Table $table): Table
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('title')->searchable()->sortable(),
-                Tables\Columns\TextColumn::make('price')->sortable(),
-                Tables\Columns\TextColumn::make('created_at')->dateTime(),
+                Tables\Columns\TextColumn::make('title')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('Owner')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('type')
+                    ->badge()
+                    ->placeholder('—'),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (?string $state) => match ($state) {
+                        'draft' => 'gray',
+                        'published' => 'success',
+                        'archived' => 'danger',
+                        default => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('price')
+                    ->money(fn ($record) => $record->currency ?? 'PKR')
+                    ->sortable()
+                    ->placeholder('—'),
+                Tables\Columns\TextColumn::make('location')
+                    ->searchable()
+                    ->placeholder('—'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
             ])
-            ->filters([])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')->options([
+                    'draft' => 'Draft',
+                    'published' => 'Published',
+                    'archived' => 'Archived',
+                ]),
+                Tables\Filters\SelectFilter::make('type')->options([
+                    'apartment' => 'Apartment',
+                    'house' => 'House',
+                    'land' => 'Land',
+                    'commercial' => 'Commercial',
+                ]),
+            ])
             ->actions([
                 Tables\Actions\EditAction::make(),
                 Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
             ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            RelationManagers\ListingsRelationManager::class,
+            RelationManagers\MediaRelationManager::class,
+        ];
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/PropertyResource/RelationManagers/ListingsRelationManager.php
+++ b/app/Filament/Resources/PropertyResource/RelationManagers/ListingsRelationManager.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Filament\Resources\PropertyResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class ListingsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'listings';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('agency.name')
+                    ->label('Agency'),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state) => match ($state) {
+                        'pending' => 'warning',
+                        'available' => 'success',
+                        'rented', 'sold' => 'info',
+                        'archived' => 'gray',
+                        default => 'gray',
+                    }),
+                Tables\Columns\IconColumn::make('user_approved')
+                    ->label('Owner Approved')
+                    ->boolean(),
+                Tables\Columns\TextColumn::make('agency_notes')
+                    ->label('Notes')
+                    ->placeholder('—')
+                    ->limit(40),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/PropertyResource/RelationManagers/MediaRelationManager.php
+++ b/app/Filament/Resources/PropertyResource/RelationManagers/MediaRelationManager.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Filament\Resources\PropertyResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\Storage;
+
+class MediaRelationManager extends RelationManager
+{
+    protected static string $relationship = 'media';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\ImageColumn::make('path')
+                    ->label('Preview')
+                    ->disk('public')
+                    ->height(60),
+                Tables\Columns\TextColumn::make('type')
+                    ->placeholder('—'),
+                Tables\Columns\TextColumn::make('caption')
+                    ->placeholder('—'),
+                Tables\Columns\TextColumn::make('sort_order')
+                    ->label('Order')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->defaultSort('sort_order')
+            ->actions([
+                Tables\Actions\DeleteAction::make()
+                    ->after(function ($record) {
+                        Storage::disk('public')->delete($record->path);
+                    }),
+            ]);
+    }
+}

--- a/app/Filament/Resources/SupportTicketResource.php
+++ b/app/Filament/Resources/SupportTicketResource.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\SupportTicketResource\Pages;
+use App\Models\SupportTicket;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class SupportTicketResource extends Resource
+{
+    protected static ?string $model = SupportTicket::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-lifebuoy';
+
+    protected static ?string $navigationBadgeTooltip = 'Open tickets';
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) static::getModel()::where('status', 'open')->count();
+    }
+
+    public static function getNavigationBadgeColor(): string|array|null
+    {
+        return static::getModel()::where('status', 'open')->exists() ? 'danger' : null;
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Select::make('user_id')
+                ->label('Submitted by')
+                ->relationship('user', 'name')
+                ->searchable()
+                ->required()
+                ->visible(fn (string $operation): bool => $operation === 'create'),
+            Forms\Components\Placeholder::make('submitted_by')
+                ->label('Submitted by')
+                ->content(fn (?SupportTicket $record) => $record?->user
+                    ? "{$record->user->name} ({$record->user->email})"
+                    : '—')
+                ->visible(fn (string $operation): bool => $operation === 'edit'),
+            Forms\Components\TextInput::make('subject')
+                ->required()
+                ->maxLength(255)
+                ->disabled(fn (string $operation): bool => $operation === 'edit'),
+            Forms\Components\Textarea::make('message')
+                ->required()
+                ->columnSpanFull()
+                ->disabled(fn (string $operation): bool => $operation === 'edit'),
+            Forms\Components\Select::make('status')
+                ->options([
+                    'open' => 'Open',
+                    'in_progress' => 'In Progress',
+                    'resolved' => 'Resolved',
+                    'closed' => 'Closed',
+                ])
+                ->default('open')
+                ->required(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('subject')
+                    ->searchable()
+                    ->limit(50),
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('Submitted by')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state) => match ($state) {
+                        'open' => 'danger',
+                        'in_progress' => 'warning',
+                        'resolved' => 'success',
+                        'closed' => 'gray',
+                        default => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Submitted')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')->options([
+                    'open' => 'Open',
+                    'in_progress' => 'In Progress',
+                    'resolved' => 'Resolved',
+                    'closed' => 'Closed',
+                ]),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListSupportTickets::route('/'),
+            'create' => Pages\CreateSupportTicket::route('/create'),
+            'edit' => Pages\EditSupportTicket::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/SupportTicketResource/Pages/CreateSupportTicket.php
+++ b/app/Filament/Resources/SupportTicketResource/Pages/CreateSupportTicket.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\SupportTicketResource\Pages;
+
+use App\Filament\Resources\SupportTicketResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateSupportTicket extends CreateRecord
+{
+    protected static string $resource = SupportTicketResource::class;
+}

--- a/app/Filament/Resources/SupportTicketResource/Pages/EditSupportTicket.php
+++ b/app/Filament/Resources/SupportTicketResource/Pages/EditSupportTicket.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\SupportTicketResource\Pages;
+
+use App\Filament\Resources\SupportTicketResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditSupportTicket extends EditRecord
+{
+    protected static string $resource = SupportTicketResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/SupportTicketResource/Pages/ListSupportTickets.php
+++ b/app/Filament/Resources/SupportTicketResource/Pages/ListSupportTickets.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\SupportTicketResource\Pages;
+
+use App\Filament\Resources\SupportTicketResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListSupportTickets extends ListRecords
+{
+    protected static string $resource = SupportTicketResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -27,7 +27,8 @@ class UserResource extends Resource
             Forms\Components\TextInput::make('phone')->maxLength(50),
             Forms\Components\TextInput::make('password')
                 ->password()
-                ->dehydrateStateUsing(fn ($state) => filled($state) ? bcrypt($state) : null)
+                // User's 'password' => 'hashed' cast already hashes on save - hashing
+                // here too would double-hash and lock the user out.
                 ->dehydrated(fn ($state) => filled($state)) // only save if provided
                 ->maxLength(255),
         ]);


### PR DESCRIPTION
## Summary
Brings everything merged into `develop` since the last sync (PR #4) into `main`:

- #11 - Fix double-hashed user passwords in the admin panel
- #12 - Flesh out admin PropertyResource (owner, type/status/filters, Listings + Media relation managers)
- #13 - Admin panel SupportTicketResource (status moderation, navigation badge, read-only submission fields)

All three were individually reviewed and merged into `develop` already; this is purely the sync, no new changes.

## Test plan
- [x] Verified on `develop` post-merge: fresh `composer install`, all admin and agency panel routes resolve correctly (Agencies, Properties, Support Tickets, Users on admin; Dashboard, Listings, Connections, Profile, API Keys on agency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)