### PR TITLE
Admin panel: ListingResource and ConnectionResource (cross-agency oversight)

### DIFF
--- a/app/Filament/Resources/ConnectionResource.php
+++ b/app/Filament/Resources/ConnectionResource.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ConnectionResource\Pages;
+use App\Models\Connection;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Infolist;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class ConnectionResource extends Resource
+{
+    protected static ?string $model = Connection::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-link';
+
+    protected static ?string $navigationGroup = 'Properties';
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('property.title')
+                    ->label('Property')
+                    ->placeholder('—')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('target_phone')
+                    ->label('Target Phone')
+                    ->placeholder('—'),
+                Tables\Columns\TextColumn::make('agency.name')
+                    ->label('Agency')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state) => match ($state) {
+                        'pending' => 'warning',
+                        'accepted' => 'success',
+                        'rejected' => 'danger',
+                        'expired' => 'gray',
+                        default => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('expires_at')
+                    ->dateTime()
+                    ->placeholder('—'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')->options([
+                    'pending' => 'Pending',
+                    'accepted' => 'Accepted',
+                    'rejected' => 'Rejected',
+                    'expired' => 'Expired',
+                ]),
+                Tables\Filters\SelectFilter::make('agency')
+                    ->relationship('agency', 'name')
+                    ->searchable(),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ]);
+    }
+
+    public static function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist->schema([
+            TextEntry::make('property.title')->label('Property')->placeholder('—'),
+            TextEntry::make('target_phone')->label('Target Phone')->placeholder('—'),
+            TextEntry::make('agency.name')->label('Agency'),
+            TextEntry::make('status')->badge(),
+            TextEntry::make('message')->placeholder('—')->columnSpanFull(),
+            TextEntry::make('expires_at')->dateTime()->placeholder('—'),
+            TextEntry::make('created_at')->dateTime(),
+        ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListConnections::route('/'),
+            'view' => Pages\ViewConnection::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ConnectionResource/Pages/ListConnections.php
+++ b/app/Filament/Resources/ConnectionResource/Pages/ListConnections.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ConnectionResource\Pages;
+
+use App\Filament\Resources\ConnectionResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListConnections extends ListRecords
+{
+    protected static string $resource = ConnectionResource::class;
+}

--- a/app/Filament/Resources/ConnectionResource/Pages/ViewConnection.php
+++ b/app/Filament/Resources/ConnectionResource/Pages/ViewConnection.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ConnectionResource\Pages;
+
+use App\Filament\Resources\ConnectionResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewConnection extends ViewRecord
+{
+    protected static string $resource = ConnectionResource::class;
+}

--- a/app/Filament/Resources/ListingResource.php
+++ b/app/Filament/Resources/ListingResource.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ListingResource\Pages;
+use App\Models\Listing;
+use Filament\Infolists\Components\IconEntry;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Infolist;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class ListingResource extends Resource
+{
+    protected static ?string $model = Listing::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-list';
+
+    protected static ?string $navigationGroup = 'Properties';
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('property.title')
+                    ->label('Property')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('agency.name')
+                    ->label('Agency')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state) => match ($state) {
+                        'pending' => 'warning',
+                        'available' => 'success',
+                        'rented', 'sold' => 'info',
+                        'archived' => 'gray',
+                        default => 'gray',
+                    }),
+                Tables\Columns\IconColumn::make('user_approved')
+                    ->label('Owner Approved')
+                    ->boolean(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')->options([
+                    'pending' => 'Pending',
+                    'available' => 'Available',
+                    'rented' => 'Rented',
+                    'sold' => 'Sold',
+                    'archived' => 'Archived',
+                ]),
+                Tables\Filters\SelectFilter::make('agency')
+                    ->relationship('agency', 'name')
+                    ->searchable(),
+                Tables\Filters\TernaryFilter::make('user_approved')
+                    ->label('Owner Approved'),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ]);
+    }
+
+    public static function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist->schema([
+            TextEntry::make('property.title')->label('Property'),
+            TextEntry::make('property.location')->label('Location')->placeholder('—'),
+            TextEntry::make('agency.name')->label('Agency'),
+            TextEntry::make('status')->badge(),
+            IconEntry::make('user_approved')->label('Owner Approved')->boolean(),
+            TextEntry::make('agency_notes')->label('Agency Notes')->placeholder('—')->columnSpanFull(),
+            TextEntry::make('approved_at')->dateTime()->placeholder('—'),
+            TextEntry::make('created_at')->dateTime(),
+        ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListListings::route('/'),
+            'view' => Pages\ViewListing::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ListingResource/Pages/ListListings.php
+++ b/app/Filament/Resources/ListingResource/Pages/ListListings.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ListingResource\Pages;
+
+use App\Filament\Resources\ListingResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListListings extends ListRecords
+{
+    protected static string $resource = ListingResource::class;
+}

--- a/app/Filament/Resources/ListingResource/Pages/ViewListing.php
+++ b/app/Filament/Resources/ListingResource/Pages/ViewListing.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ListingResource\Pages;
+
+use App\Filament\Resources\ListingResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewListing extends ViewRecord
+{
+    protected static string $resource = ListingResource::class;
+}


### PR DESCRIPTION
## Summary
Neither Listings nor Connections had any admin-side visibility - each agency only sees its own via their panel, so an admin investigating a dispute had no way to see them without querying the database directly.

Both are **read-only oversight** (List + View via Infolists; `canCreate()` returns false, no edit/delete actions wired up):

- `ListingResource`: property, agency, status badge, owner-approval icon. Filters: status, agency, and a `TernaryFilter` on `user_approved`.
- `ConnectionResource`: property-or-`target_phone`, agency, status badge, expiry. Filters: status, agency.

## Why no status-change action
Doing this properly for admin would need a way to attribute the change in the audit trail, but `listing_status_histories` only has `changed_by_agency_id` and `changed_by_user_id` columns - no `changed_by_admin_id`. That's a schema decision I didn't want to make silently, so I'm flagging it as a follow-up rather than building a mutation path with a real audit-trail gap or bypassing the existing agency/owner-only status flow without a clear way to log it.

## Test plan
- [x] Both lists show real data spanning multiple different agencies for the same property (e.g. "Hegmann Way" listed by two different agencies) - proves this is genuinely cross-agency, not accidentally scoped to one
- [x] Status filter, agency filter, and the `user_approved` TernaryFilter all verified via query string, each returning exactly the expected subset
- [x] View pages render the Infolist correctly for both Connection shapes (property-based and `target_phone`-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)