### PR TITLE
Add admin:create command to seed a real admin account

### DIFF
--- a/app/Console/Commands/CreateAdminCommand.php
+++ b/app/Console/Commands/CreateAdminCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Admin;
+use Filament\Facades\Filament;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Hash;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+use function Laravel\Prompts\password;
+use function Laravel\Prompts\text;
+
+#[AsCommand(name: 'admin:create')]
+class CreateAdminCommand extends Command
+{
+    protected $signature = 'admin:create
+                            {--name= : The admin\'s name}
+                            {--email= : A valid and unique email address}
+                            {--password= : The password (min. 8 characters)}';
+
+    protected $description = 'Create an admin account for the admin panel';
+
+    public function handle(): int
+    {
+        $name = $this->option('name') ?? text(
+            label: 'Name',
+            required: true,
+        );
+
+        $email = $this->option('email') ?? text(
+            label: 'Email address',
+            required: true,
+            validate: fn (string $email): ?string => $this->validateEmail($email),
+        );
+
+        $plainPassword = $this->option('password') ?? password(
+            label: 'Password',
+            required: true,
+            validate: fn (string $value): ?string => $this->validatePassword($value),
+        );
+
+        // Options bypass the prompt validation above, so re-check here to
+        // avoid a raw DB constraint error or a silently-too-short password.
+        if ($error = $this->validateEmail($email)) {
+            $this->components->error($error);
+
+            return self::FAILURE;
+        }
+
+        if ($error = $this->validatePassword($plainPassword)) {
+            $this->components->error($error);
+
+            return self::FAILURE;
+        }
+
+        $admin = Admin::create([
+            'name' => $name,
+            'email' => $email,
+            'password' => Hash::make($plainPassword),
+        ]);
+
+        $loginUrl = Filament::getPanel('admin')->getLoginUrl();
+
+        $this->components->info("Admin account created for {$admin->email}. Log in at {$loginUrl}");
+
+        return self::SUCCESS;
+    }
+
+    private function validateEmail(string $email): ?string
+    {
+        return match (true) {
+            ! filter_var($email, FILTER_VALIDATE_EMAIL) => 'The email address must be valid.',
+            Admin::where('email', $email)->exists() => 'An admin with this email address already exists.',
+            default => null,
+        };
+    }
+
+    private function validatePassword(string $password): ?string
+    {
+        return strlen($password) < 8
+            ? 'The password must be at least 8 characters.'
+            : null;
+    }
+}


### PR DESCRIPTION
## Summary
There was no `AdminSeeder` and no way to create an `Admin` account at all except `tinker` - a fresh install has zero admins and thus no way into `/admin`. Deliberately **not** a seeder with hardcoded credentials: this is a public repo, and baking a known admin email/password into committed seed data would be a real credential sitting in plain sight, not a placeholder.

## Why not Filament's own `make:filament-user`?
Tried it first. It resolves the target model via `Filament::auth()->getProvider()`, which is ambiguous here since both `AdminPanelProvider` and `AgencyPanelProvider` call `->default()`. Confirmed by actually running it: **it silently created the account as an Agency, not an Admin.** Writing a dedicated `admin:create` command sidesteps the panel-resolution ambiguity entirely by targeting `App\Models\Admin` explicitly, without touching the panel providers (a separate, riskier change).

## Usage
```
php artisan admin:create
php artisan admin:create --name="Jane Doe" --email=jane@example.com --password=correct-horse-battery
```
Supports both interactive prompts (Laravel Prompts, matching Filament's own command's UX) and options for scripted/CI use.

## A bug I caught while building this
Validation initially only ran on the interactive prompt path. Passing a duplicate email via `--email` would have hit the DB's unique constraint directly and thrown a raw, unhandled exception instead of a clean error. Fixed by re-validating both fields after gathering values, regardless of source.

## Test plan
- [x] Confirmed the created record is genuinely an `Admin` (not `Agency`)
- [x] Password hashes exactly once - `Admin` has no auto-hashing cast/mutator (unlike `Agency`'s `setPasswordAttribute` and `User`'s `'password' => 'hashed'` cast), so this command hashes explicitly and correctly
- [x] Full round-trip: logged in through the real `/admin/login` flow with the created credentials
- [x] Duplicate email via `--email` and a too-short password via `--password` are both rejected with a clean error and no stray record created

🤖 Generated with [Claude Code](https://claude.com/claude-code)