### PR TITLE
Remove unused spatie/laravel-permission package

### DIFF
--- a/bootstrap/cache/packages.php
+++ b/bootstrap/cache/packages.php
@@ -168,13 +168,6 @@
       0 => 'RyanChandler\\BladeCaptureDirective\\BladeCaptureDirectiveServiceProvider',
     ),
   ),
-  'spatie/laravel-permission' => 
-  array (
-    'providers' => 
-    array (
-      0 => 'Spatie\\Permission\\PermissionServiceProvider',
-    ),
-  ),
   'spatie/laravel-query-builder' => 
   array (
     'providers' => 

--- a/bootstrap/cache/services.php
+++ b/bootstrap/cache/services.php
@@ -46,11 +46,10 @@
     42 => 'Termwind\\Laravel\\TermwindServiceProvider',
     43 => 'Pest\\Laravel\\PestServiceProvider',
     44 => 'RyanChandler\\BladeCaptureDirective\\BladeCaptureDirectiveServiceProvider',
-    45 => 'Spatie\\Permission\\PermissionServiceProvider',
-    46 => 'Spatie\\QueryBuilder\\QueryBuilderServiceProvider',
-    47 => 'App\\Providers\\AppServiceProvider',
-    48 => 'App\\Providers\\Filament\\AdminPanelProvider',
-    49 => 'App\\Providers\\Filament\\AgencyPanelProvider',
+    45 => 'Spatie\\QueryBuilder\\QueryBuilderServiceProvider',
+    46 => 'App\\Providers\\AppServiceProvider',
+    47 => 'App\\Providers\\Filament\\AdminPanelProvider',
+    48 => 'App\\Providers\\Filament\\AgencyPanelProvider',
   ),
   'eager' => 
   array (
@@ -83,11 +82,10 @@
     26 => 'Termwind\\Laravel\\TermwindServiceProvider',
     27 => 'Pest\\Laravel\\PestServiceProvider',
     28 => 'RyanChandler\\BladeCaptureDirective\\BladeCaptureDirectiveServiceProvider',
-    29 => 'Spatie\\Permission\\PermissionServiceProvider',
-    30 => 'Spatie\\QueryBuilder\\QueryBuilderServiceProvider',
-    31 => 'App\\Providers\\AppServiceProvider',
-    32 => 'App\\Providers\\Filament\\AdminPanelProvider',
-    33 => 'App\\Providers\\Filament\\AgencyPanelProvider',
+    29 => 'Spatie\\QueryBuilder\\QueryBuilderServiceProvider',
+    30 => 'App\\Providers\\AppServiceProvider',
+    31 => 'App\\Providers\\Filament\\AdminPanelProvider',
+    32 => 'App\\Providers\\Filament\\AgencyPanelProvider',
   ),
   'deferred' => 
   array (

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.10.1",
-        "spatie/laravel-permission": "^6.21",
         "spatie/laravel-query-builder": "^6.3"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c1a444c0675e653bb795cbd733cac0f",
+    "content-hash": "11c82ee516213b73a0771d2525c91806",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -4938,89 +4938,6 @@
                 }
             ],
             "time": "2025-07-17T15:46:43+00:00"
-        },
-        {
-            "name": "spatie/laravel-permission",
-            "version": "6.21.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/spatie/laravel-permission.git",
-                "reference": "6a118e8855dfffcd90403aab77bbf35a03db51b3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-permission/zipball/6a118e8855dfffcd90403aab77bbf35a03db51b3",
-                "reference": "6a118e8855dfffcd90403aab77bbf35a03db51b3",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/auth": "^8.12|^9.0|^10.0|^11.0|^12.0",
-                "illuminate/container": "^8.12|^9.0|^10.0|^11.0|^12.0",
-                "illuminate/contracts": "^8.12|^9.0|^10.0|^11.0|^12.0",
-                "illuminate/database": "^8.12|^9.0|^10.0|^11.0|^12.0",
-                "php": "^8.0"
-            },
-            "require-dev": {
-                "laravel/passport": "^11.0|^12.0",
-                "laravel/pint": "^1.0",
-                "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0|^10.0",
-                "phpunit/phpunit": "^9.4|^10.1|^11.5"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Spatie\\Permission\\PermissionServiceProvider"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-main": "6.x-dev",
-                    "dev-master": "6.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/helpers.php"
-                ],
-                "psr-4": {
-                    "Spatie\\Permission\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Freek Van der Herten",
-                    "email": "freek@spatie.be",
-                    "homepage": "https://spatie.be",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Permission handling for Laravel 8.0 and up",
-            "homepage": "https://github.com/spatie/laravel-permission",
-            "keywords": [
-                "acl",
-                "laravel",
-                "permission",
-                "permissions",
-                "rbac",
-                "roles",
-                "security",
-                "spatie"
-            ],
-            "support": {
-                "issues": "https://github.com/spatie/laravel-permission/issues",
-                "source": "https://github.com/spatie/laravel-permission/tree/6.21.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/spatie",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-07-23T16:08:05+00:00"
         },
         {
             "name": "spatie/laravel-query-builder",


### PR DESCRIPTION
## Summary
Installed but never actually integrated: its migration was never published or run (no `roles`/`permissions`/`model_has_roles` tables exist in the schema), and nothing in `app/` references `Spatie\Permission` anywhere. Every Admin currently has unconditional full access with no role distinction at all - this package sitting in `composer.json` didn't change that, it just added dependency weight for a capability that was never wired up.

If role-based access control is wanted later, that's real feature work - deciding the actual permission boundaries, running the migration, gating each Filament resource accordingly, likely a roles management UI - not something to leave half-installed in the meantime. Re-adding the package is one `composer require` away when that's actually scoped.

## How this was removed
Learned from the earlier ERD-package incident: used a **scoped** `composer update spatie/laravel-permission` rather than a bare `composer update`, specifically to avoid silently bumping `filament/filament` (which has no version constraint - `"*"` - and jumped to a breaking v5 last time I ran an unscoped update). Confirmed via the `composer.lock` diff that Filament and every other package stayed pinned at their existing versions this time.

## Test plan
- [x] `composer.lock` diff shows only the one package removed, nothing else moved
- [x] `spatie/laravel-query-builder` (the *other*, still-used Spatie package) confirmed untouched in the regenerated bootstrap cache
- [x] Admin and agency panel routes all resolve correctly post-removal
- [x] A basic Eloquent query still runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)