### PR TITLE
Sync develop to main: public home/browse pages + rebrand

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-APP_NAME=MyPropertyStatus
+APP_NAME="SkyProperty - SP"
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true

--- a/app/Http/Controllers/Api/PropertyController.php
+++ b/app/Http/Controllers/Api/PropertyController.php
@@ -4,43 +4,24 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\Property;
+use App\Services\PropertyService;
 use Illuminate\Http\Request;
 
 class PropertyController extends Controller
 {
+    public function __construct(private PropertyService $properties) {}
+
     /**
      * List published properties with filters & pagination. Public.
      */
     public function index(Request $request)
     {
-        $query = Property::query()->where('status', 'published');
+        $query = $this->properties->filter(
+            $this->properties->published(),
+            $request->only(['location', 'min_price', 'max_price', 'agency_id', 'type'])
+        );
 
-        // Filtering
-        if ($request->filled('location')) {
-            $query->where('location', 'like', '%' . $request->location . '%');
-        }
-
-        if ($request->filled('min_price')) {
-            $query->where('price', '>=', $request->min_price);
-        }
-
-        if ($request->filled('max_price')) {
-            $query->where('price', '<=', $request->max_price);
-        }
-
-        if ($request->filled('agency_id')) {
-            $query->whereHas('listings', function ($q) use ($request) {
-                $q->where('agency_id', $request->agency_id);
-            });
-        }
-
-        if ($request->filled('type')) {
-            $query->where('type', $request->type);
-        }
-
-        $properties = $query->with(['listings.agency', 'media'])->paginate(10);
-
-        return response()->json($properties);
+        return response()->json($query->paginate(10));
     }
 
     /**
@@ -48,9 +29,7 @@ class PropertyController extends Controller
      */
     public function show($id)
     {
-        $property = Property::where('status', 'published')
-            ->with(['listings.agency', 'media'])
-            ->findOrFail($id);
+        $property = $this->properties->published()->findOrFail($id);
 
         return response()->json($property);
     }

--- a/app/Livewire/Public/Browse.php
+++ b/app/Livewire/Public/Browse.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Livewire\Public;
+
+use App\Services\PropertyService;
+use Livewire\Attributes\Layout;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+#[Layout('layouts.public')]
+class Browse extends Component
+{
+    use WithPagination;
+
+    #[Url]
+    public string $location = '';
+
+    #[Url]
+    public string $type = '';
+
+    #[Url]
+    public string $min_price = '';
+
+    #[Url]
+    public string $max_price = '';
+
+    public function updated(): void
+    {
+        $this->resetPage();
+    }
+
+    public function render()
+    {
+        $properties = app(PropertyService::class);
+
+        $query = $properties->filter($properties->published(), [
+            'location' => $this->location,
+            'type' => $this->type,
+            'min_price' => $this->min_price,
+            'max_price' => $this->max_price,
+        ]);
+
+        return view('livewire.public.browse', [
+            'properties' => $query->latest()->paginate(9),
+        ]);
+    }
+}

--- a/app/Livewire/Public/Home.php
+++ b/app/Livewire/Public/Home.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Livewire\Public;
+
+use App\Services\PropertyService;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('layouts.public')]
+class Home extends Component
+{
+    public function render()
+    {
+        $properties = app(PropertyService::class);
+
+        return view('livewire.public.home', [
+            'recentProperties' => $properties->published()->latest()->take(6)->get(),
+        ]);
+    }
+}

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -12,6 +12,14 @@ class Property extends Model
 
     protected $guarded = [];
 
+    protected function casts(): array
+    {
+        return [
+            'details' => 'array',
+            'price' => 'decimal:2',
+        ];
+    }
+
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/app/Services/PropertyService.php
+++ b/app/Services/PropertyService.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Property;
+use Illuminate\Database\Eloquent\Builder;
+
+class PropertyService
+{
+    /**
+     * Base query for publicly browsable properties.
+     */
+    public function published(): Builder
+    {
+        return Property::query()
+            ->where('status', 'published')
+            ->with(['listings.agency', 'media']);
+    }
+
+    /**
+     * Apply the standard browse filters (location, price range, type, agency) to a query.
+     */
+    public function filter(Builder $query, array $filters): Builder
+    {
+        if (! empty($filters['location'])) {
+            $query->where('location', 'like', '%'.$filters['location'].'%');
+        }
+
+        if (! empty($filters['min_price'])) {
+            $query->where('price', '>=', $filters['min_price']);
+        }
+
+        if (! empty($filters['max_price'])) {
+            $query->where('price', '<=', $filters['max_price']);
+        }
+
+        if (! empty($filters['agency_id'])) {
+            $query->whereHas('listings', function ($q) use ($filters) {
+                $q->where('agency_id', $filters['agency_id']);
+            });
+        }
+
+        if (! empty($filters['type'])) {
+            $query->where('type', $filters['type']);
+        }
+
+        return $query;
+    }
+}

--- a/database/factories/PropertyFactory.php
+++ b/database/factories/PropertyFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Property;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class PropertyFactory extends Factory
@@ -12,9 +13,29 @@ class PropertyFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id' => \App\Models\User::factory(),
+            'user_id' => User::factory(),
             'title' => $this->faker->streetName(),
-            'status' => 'draft'
+            'description' => $this->faker->paragraph(),
+            'type' => $this->faker->randomElement(['apartment', 'house', 'land', 'commercial']),
+            'currency' => 'PKR',
+            'price' => $this->faker->numberBetween(2_000_000, 50_000_000),
+            'status' => $this->faker->randomElement(['draft', 'draft', 'published', 'published', 'archived']),
+            'location' => $this->faker->city(),
+            'details' => [
+                'bedrooms' => $this->faker->numberBetween(1, 6),
+                'bathrooms' => $this->faker->numberBetween(1, 4),
+                'area_sqft' => $this->faker->numberBetween(500, 5000),
+            ],
         ];
+    }
+
+    public function published(): static
+    {
+        return $this->state(['status' => 'published']);
+    }
+
+    public function draft(): static
+    {
+        return $this->state(['status' => 'draft']);
     }
 }

--- a/resources/views/components/brand-logo.blade.php
+++ b/resources/views/components/brand-logo.blade.php
@@ -1,0 +1,4 @@
+<a href="{{ route('home') }}" class="flex items-baseline gap-1.5">
+    <span class="text-lg font-bold text-green-700">SkyProperty</span>
+    <span class="rounded bg-green-700 px-1 py-0.5 text-[10px] font-bold leading-none text-white">SP</span>
+</a>

--- a/resources/views/components/primary-button.blade.php
+++ b/resources/views/components/primary-button.blade.php
@@ -1,3 +1,3 @@
-<button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex w-full items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-700 disabled:opacity-50']) }}>
+<button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex w-full items-center justify-center rounded-md bg-green-700 px-4 py-2 text-sm font-semibold text-white hover:bg-green-800 disabled:opacity-50']) }}>
     {{ $slot }}
 </button>

--- a/resources/views/components/property-card.blade.php
+++ b/resources/views/components/property-card.blade.php
@@ -1,0 +1,52 @@
+@props(['property'])
+
+<article class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+    <div class="aspect-video bg-gray-100">
+        @php($image = $property->media->firstWhere('type', 'image'))
+        @if ($image)
+            <img src="{{ asset('storage/'.$image->path) }}" alt="{{ $property->title }}" class="h-full w-full object-cover">
+        @else
+            <div class="flex h-full w-full items-center justify-center text-sm text-gray-400">
+                No image
+            </div>
+        @endif
+    </div>
+
+    <div class="space-y-2 p-4">
+        <div class="flex items-start justify-between gap-2">
+            <h3 class="font-semibold text-gray-900">{{ $property->title }}</h3>
+
+            @if ($property->type)
+                <span class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+                    {{ ucfirst($property->type) }}
+                </span>
+            @endif
+        </div>
+
+        @if ($property->location)
+            <p class="text-sm text-gray-500">{{ $property->location }}</p>
+        @endif
+
+        <p class="text-lg font-semibold text-gray-900">
+            @if ($property->price)
+                {{ $property->currency ?? 'PKR' }} {{ number_format($property->price) }}
+            @else
+                Price on request
+            @endif
+        </p>
+
+        @php($details = collect([
+            isset($property->details['bedrooms']) ? $property->details['bedrooms'].' bed' : null,
+            isset($property->details['bathrooms']) ? $property->details['bathrooms'].' bath' : null,
+            isset($property->details['area_sqft']) ? $property->details['area_sqft'].' sqft' : null,
+        ])->filter())
+        @if ($details->isNotEmpty())
+            <p class="text-sm text-gray-500">{{ $details->join(' · ') }}</p>
+        @endif
+
+        @php($agency = $property->listings->first()?->agency)
+        @if ($agency)
+            <p class="text-xs text-gray-400">Listed by {{ $agency->name }}</p>
+        @endif
+    </div>
+</article>

--- a/resources/views/components/property-card.blade.php
+++ b/resources/views/components/property-card.blade.php
@@ -17,7 +17,7 @@
             <h3 class="font-semibold text-gray-900">{{ $property->title }}</h3>
 
             @if ($property->type)
-                <span class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+                <span class="shrink-0 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700">
                     {{ ucfirst($property->type) }}
                 </span>
             @endif

--- a/resources/views/components/text-input.blade.php
+++ b/resources/views/components/text-input.blade.php
@@ -1,3 +1,3 @@
 @props(['disabled' => false])
 
-<input @disabled($disabled) {{ $attributes->merge(['class' => 'block w-full rounded-md border-gray-300 shadow-sm focus:border-gray-900 focus:ring-gray-900 sm:text-sm']) }}>
+<input @disabled($disabled) {{ $attributes->merge(['class' => 'block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm']) }}>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ config('app.name', 'MyPropertyStatus') }}</title>
+    <title>{{ config('app.name', 'SkyProperty - SP') }}</title>
 
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     @livewireStyles
@@ -12,17 +12,15 @@
     <div class="min-h-screen flex flex-col">
         <header class="border-b border-gray-200 bg-white">
             <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-                <a href="{{ route('dashboard') }}" class="text-lg font-semibold text-gray-900">
-                    {{ config('app.name', 'MyPropertyStatus') }}
-                </a>
+                <x-brand-logo />
 
                 <nav class="flex items-center gap-4 text-sm">
-                    <a href="{{ route('dashboard') }}" class="text-gray-600 hover:text-gray-900">Dashboard</a>
-                    <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-gray-900">Browse properties</a>
+                    <a href="{{ route('dashboard') }}" class="text-gray-600 hover:text-green-700">Dashboard</a>
+                    <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-green-700">Browse properties</a>
 
                     <form method="POST" action="{{ route('logout') }}">
                         @csrf
-                        <button type="submit" class="text-gray-600 hover:text-gray-900">Log out</button>
+                        <button type="submit" class="text-gray-600 hover:text-green-700">Log out</button>
                     </form>
                 </nav>
             </div>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -12,11 +12,13 @@
     <div class="min-h-screen flex flex-col">
         <header class="border-b border-gray-200 bg-white">
             <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-                <a href="{{ url('/') }}" class="text-lg font-semibold text-gray-900">
+                <a href="{{ route('home') }}" class="text-lg font-semibold text-gray-900">
                     {{ config('app.name', 'MyPropertyStatus') }}
                 </a>
 
                 <nav class="flex items-center gap-4 text-sm">
+                    <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-gray-900">Browse properties</a>
+
                     @if (! request()->routeIs('login'))
                         <a href="{{ route('login') }}" class="text-gray-600 hover:text-gray-900">Log in</a>
                     @endif

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ config('app.name', 'MyPropertyStatus') }}</title>
+    <title>{{ config('app.name', 'SkyProperty - SP') }}</title>
 
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     @livewireStyles
@@ -12,19 +12,17 @@
     <div class="min-h-screen flex flex-col">
         <header class="border-b border-gray-200 bg-white">
             <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-                <a href="{{ route('home') }}" class="text-lg font-semibold text-gray-900">
-                    {{ config('app.name', 'MyPropertyStatus') }}
-                </a>
+                <x-brand-logo />
 
                 <nav class="flex items-center gap-4 text-sm">
-                    <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-gray-900">Browse properties</a>
+                    <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-green-700">Browse properties</a>
 
                     @if (! request()->routeIs('login'))
-                        <a href="{{ route('login') }}" class="text-gray-600 hover:text-gray-900">Log in</a>
+                        <a href="{{ route('login') }}" class="text-gray-600 hover:text-green-700">Log in</a>
                     @endif
 
                     @if (! request()->routeIs('register'))
-                        <a href="{{ route('register') }}" class="rounded-md bg-gray-900 px-4 py-2 text-white hover:bg-gray-700">
+                        <a href="{{ route('register') }}" class="rounded-md bg-green-700 px-4 py-2 text-white hover:bg-green-800">
                             Register
                         </a>
                     @endif

--- a/resources/views/layouts/public.blade.php
+++ b/resources/views/layouts/public.blade.php
@@ -12,18 +12,26 @@
     <div class="min-h-screen flex flex-col">
         <header class="border-b border-gray-200 bg-white">
             <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-                <a href="{{ route('dashboard') }}" class="text-lg font-semibold text-gray-900">
+                <a href="{{ route('home') }}" class="text-lg font-semibold text-gray-900">
                     {{ config('app.name', 'MyPropertyStatus') }}
                 </a>
 
                 <nav class="flex items-center gap-4 text-sm">
-                    <a href="{{ route('dashboard') }}" class="text-gray-600 hover:text-gray-900">Dashboard</a>
                     <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-gray-900">Browse properties</a>
 
-                    <form method="POST" action="{{ route('logout') }}">
-                        @csrf
-                        <button type="submit" class="text-gray-600 hover:text-gray-900">Log out</button>
-                    </form>
+                    @auth
+                        <a href="{{ route('dashboard') }}" class="text-gray-600 hover:text-gray-900">Dashboard</a>
+
+                        <form method="POST" action="{{ route('logout') }}">
+                            @csrf
+                            <button type="submit" class="text-gray-600 hover:text-gray-900">Log out</button>
+                        </form>
+                    @else
+                        <a href="{{ route('login') }}" class="text-gray-600 hover:text-gray-900">Log in</a>
+                        <a href="{{ route('register') }}" class="rounded-md bg-gray-900 px-4 py-2 text-white hover:bg-gray-700">
+                            Register
+                        </a>
+                    @endauth
                 </nav>
             </div>
         </header>

--- a/resources/views/layouts/public.blade.php
+++ b/resources/views/layouts/public.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ config('app.name', 'MyPropertyStatus') }}</title>
+    <title>{{ config('app.name', 'SkyProperty - SP') }}</title>
 
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     @livewireStyles
@@ -12,27 +12,47 @@
     <div class="min-h-screen flex flex-col">
         <header class="border-b border-gray-200 bg-white">
             <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-                <a href="{{ route('home') }}" class="text-lg font-semibold text-gray-900">
-                    {{ config('app.name', 'MyPropertyStatus') }}
-                </a>
+                <x-brand-logo />
 
                 <nav class="flex items-center gap-4 text-sm">
-                    <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-gray-900">Browse properties</a>
+                    <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-green-700">Browse properties</a>
 
                     @auth
-                        <a href="{{ route('dashboard') }}" class="text-gray-600 hover:text-gray-900">Dashboard</a>
+                        <a href="{{ route('dashboard') }}" class="text-gray-600 hover:text-green-700">Dashboard</a>
 
                         <form method="POST" action="{{ route('logout') }}">
                             @csrf
-                            <button type="submit" class="text-gray-600 hover:text-gray-900">Log out</button>
+                            <button type="submit" class="text-gray-600 hover:text-green-700">Log out</button>
                         </form>
                     @else
-                        <a href="{{ route('login') }}" class="text-gray-600 hover:text-gray-900">Log in</a>
-                        <a href="{{ route('register') }}" class="rounded-md bg-gray-900 px-4 py-2 text-white hover:bg-gray-700">
+                        <a href="{{ route('login') }}" class="text-gray-600 hover:text-green-700">Log in</a>
+                        <a href="{{ route('register') }}" class="rounded-md bg-green-700 px-4 py-2 text-white hover:bg-green-800">
                             Register
                         </a>
                     @endauth
                 </nav>
+            </div>
+
+            <div class="border-t border-gray-100">
+                <div class="mx-auto flex max-w-6xl items-center gap-6 px-6 py-2.5 text-sm">
+                    @php($currentType = request()->query('type'))
+
+                    <a href="{{ route('properties.index') }}" class="font-semibold {{ request()->routeIs('properties.index') && ! $currentType ? 'text-green-700' : 'text-gray-500 hover:text-green-700' }}">
+                        All
+                    </a>
+                    <a href="{{ route('properties.index', ['type' => 'apartment']) }}" class="{{ $currentType === 'apartment' ? 'font-semibold text-green-700' : 'text-gray-500 hover:text-green-700' }}">
+                        Apartments
+                    </a>
+                    <a href="{{ route('properties.index', ['type' => 'house']) }}" class="{{ $currentType === 'house' ? 'font-semibold text-green-700' : 'text-gray-500 hover:text-green-700' }}">
+                        Houses
+                    </a>
+                    <a href="{{ route('properties.index', ['type' => 'land']) }}" class="{{ $currentType === 'land' ? 'font-semibold text-green-700' : 'text-gray-500 hover:text-green-700' }}">
+                        Land
+                    </a>
+                    <a href="{{ route('properties.index', ['type' => 'commercial']) }}" class="{{ $currentType === 'commercial' ? 'font-semibold text-green-700' : 'text-gray-500 hover:text-green-700' }}">
+                        Commercial
+                    </a>
+                </div>
             </div>
         </header>
 

--- a/resources/views/livewire/public/browse.blade.php
+++ b/resources/views/livewire/public/browse.blade.php
@@ -1,0 +1,43 @@
+<div class="space-y-8">
+    <h1 class="text-2xl font-semibold text-gray-900">Browse properties</h1>
+
+    <div class="grid gap-4 rounded-lg border border-gray-200 bg-white p-4 sm:grid-cols-4">
+        <div>
+            <x-input-label for="location" value="Location" />
+            <x-text-input wire:model.live.debounce.300ms="location" id="location" type="text" placeholder="City or area" />
+        </div>
+
+        <div>
+            <x-input-label for="type" value="Type" />
+            <select wire:model.live="type" id="type" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-gray-900 focus:ring-gray-900 sm:text-sm">
+                <option value="">Any type</option>
+                <option value="apartment">Apartment</option>
+                <option value="house">House</option>
+                <option value="land">Land</option>
+                <option value="commercial">Commercial</option>
+            </select>
+        </div>
+
+        <div>
+            <x-input-label for="min_price" value="Min price" />
+            <x-text-input wire:model.live.debounce.300ms="min_price" id="min_price" type="number" min="0" />
+        </div>
+
+        <div>
+            <x-input-label for="max_price" value="Max price" />
+            <x-text-input wire:model.live.debounce.300ms="max_price" id="max_price" type="number" min="0" />
+        </div>
+    </div>
+
+    @if ($properties->isEmpty())
+        <p class="text-gray-500">No properties match your search.</p>
+    @else
+        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            @foreach ($properties as $property)
+                <x-property-card :property="$property" />
+            @endforeach
+        </div>
+
+        {{ $properties->links() }}
+    @endif
+</div>

--- a/resources/views/livewire/public/browse.blade.php
+++ b/resources/views/livewire/public/browse.blade.php
@@ -9,7 +9,7 @@
 
         <div>
             <x-input-label for="type" value="Type" />
-            <select wire:model.live="type" id="type" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-gray-900 focus:ring-gray-900 sm:text-sm">
+            <select wire:model.live="type" id="type" class="block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm">
                 <option value="">Any type</option>
                 <option value="apartment">Apartment</option>
                 <option value="house">House</option>

--- a/resources/views/livewire/public/home.blade.php
+++ b/resources/views/livewire/public/home.blade.php
@@ -1,17 +1,17 @@
 <div class="space-y-16">
-    <section class="rounded-2xl bg-gray-900 px-8 py-16 text-center text-white">
+    <section class="rounded-2xl bg-green-700 px-8 py-16 text-center text-white">
         <h1 class="text-3xl font-bold sm:text-4xl">Find your next property</h1>
-        <p class="mt-3 text-gray-300">Browse verified listings from agencies across the country.</p>
+        <p class="mt-3 text-green-50">Browse verified listings from agencies across the country.</p>
 
         <form method="GET" action="{{ route('properties.index') }}" class="mx-auto mt-8 flex max-w-xl flex-col gap-3 sm:flex-row">
             <input
                 type="text"
                 name="location"
                 placeholder="City or area"
-                class="w-full rounded-md border-0 bg-white px-4 py-2 text-gray-900 shadow-sm focus:ring-2 focus:ring-white sm:flex-1"
+                class="w-full rounded-md border-0 bg-white px-4 py-2 text-gray-900 shadow-sm outline-none focus:ring-2 focus:ring-green-900 sm:flex-1"
             >
 
-            <select name="type" class="w-full rounded-md border-0 bg-white px-4 py-2 text-gray-900 shadow-sm focus:ring-2 focus:ring-white sm:w-40">
+            <select name="type" class="w-full rounded-md border-0 bg-white px-4 py-2 text-gray-900 shadow-sm outline-none focus:ring-2 focus:ring-green-900 sm:w-40">
                 <option value="">Any type</option>
                 <option value="apartment">Apartment</option>
                 <option value="house">House</option>
@@ -19,7 +19,7 @@
                 <option value="commercial">Commercial</option>
             </select>
 
-            <button type="submit" class="rounded-md bg-white px-6 py-2 font-semibold text-gray-900 hover:bg-gray-100">
+            <button type="submit" class="rounded-md bg-white px-6 py-2 font-semibold text-green-700 hover:bg-green-50">
                 Search
             </button>
         </form>
@@ -28,7 +28,7 @@
     <section>
         <div class="mb-6 flex items-center justify-between">
             <h2 class="text-xl font-semibold text-gray-900">Recently listed</h2>
-            <a href="{{ route('properties.index') }}" class="text-sm text-gray-600 hover:text-gray-900">View all &rarr;</a>
+            <a href="{{ route('properties.index') }}" class="text-sm text-gray-600 hover:text-green-700">View all &rarr;</a>
         </div>
 
         @if ($recentProperties->isEmpty())

--- a/resources/views/livewire/public/home.blade.php
+++ b/resources/views/livewire/public/home.blade.php
@@ -1,0 +1,44 @@
+<div class="space-y-16">
+    <section class="rounded-2xl bg-gray-900 px-8 py-16 text-center text-white">
+        <h1 class="text-3xl font-bold sm:text-4xl">Find your next property</h1>
+        <p class="mt-3 text-gray-300">Browse verified listings from agencies across the country.</p>
+
+        <form method="GET" action="{{ route('properties.index') }}" class="mx-auto mt-8 flex max-w-xl flex-col gap-3 sm:flex-row">
+            <input
+                type="text"
+                name="location"
+                placeholder="City or area"
+                class="w-full rounded-md border-0 bg-white px-4 py-2 text-gray-900 shadow-sm focus:ring-2 focus:ring-white sm:flex-1"
+            >
+
+            <select name="type" class="w-full rounded-md border-0 bg-white px-4 py-2 text-gray-900 shadow-sm focus:ring-2 focus:ring-white sm:w-40">
+                <option value="">Any type</option>
+                <option value="apartment">Apartment</option>
+                <option value="house">House</option>
+                <option value="land">Land</option>
+                <option value="commercial">Commercial</option>
+            </select>
+
+            <button type="submit" class="rounded-md bg-white px-6 py-2 font-semibold text-gray-900 hover:bg-gray-100">
+                Search
+            </button>
+        </form>
+    </section>
+
+    <section>
+        <div class="mb-6 flex items-center justify-between">
+            <h2 class="text-xl font-semibold text-gray-900">Recently listed</h2>
+            <a href="{{ route('properties.index') }}" class="text-sm text-gray-600 hover:text-gray-900">View all &rarr;</a>
+        </div>
+
+        @if ($recentProperties->isEmpty())
+            <p class="text-gray-500">No properties are published yet. Check back soon.</p>
+        @else
+            <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                @foreach ($recentProperties as $property)
+                    <x-property-card :property="$property" />
+                @endforeach
+            </div>
+        @endif
+    </section>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,11 +1,12 @@
 <?php
 
 use App\Livewire\Dashboard;
+use App\Livewire\Public\Browse;
+use App\Livewire\Public\Home;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return ['MyPropertyStatus' => app()->version()];
-});
+Route::get('/', Home::class)->name('home');
+Route::get('/properties', Browse::class)->name('properties.index');
 
 Route::get('/dashboard', Dashboard::class)
     ->middleware('auth')

--- a/tests/Feature/PropertyBrowsingApiTest.php
+++ b/tests/Feature/PropertyBrowsingApiTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Models\Property;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+test('public index only returns published properties', function () {
+    Property::factory()->published()->create(['title' => 'Published One']);
+    Property::factory()->draft()->create(['title' => 'Draft One']);
+
+    $response = $this->getJson('/api/properties');
+
+    $response->assertOk();
+    $titles = collect($response->json('data'))->pluck('title');
+
+    expect($titles)->toContain('Published One');
+    expect($titles)->not->toContain('Draft One');
+});
+
+test('public show 404s for a draft property', function () {
+    $draft = Property::factory()->draft()->create();
+
+    $this->getJson("/api/properties/{$draft->id}")->assertNotFound();
+});
+
+test('public show returns a published property', function () {
+    $published = Property::factory()->published()->create();
+
+    $this->getJson("/api/properties/{$published->id}")
+        ->assertOk()
+        ->assertJsonPath('id', $published->id);
+});
+
+test('my-properties returns the owner\'s properties regardless of status', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+
+    Property::factory()->published()->create(['user_id' => $owner->id]);
+    Property::factory()->draft()->create(['user_id' => $owner->id]);
+    Property::factory()->published()->create(['user_id' => $other->id]);
+
+    Sanctum::actingAs($owner);
+
+    $response = $this->getJson('/api/my-properties');
+
+    $response->assertOk();
+    expect($response->json('data'))->toHaveCount(2);
+});
+
+test('my-properties requires authentication', function () {
+    $this->getJson('/api/my-properties')->assertUnauthorized();
+});

--- a/tests/Feature/Public/BrowseTest.php
+++ b/tests/Feature/Public/BrowseTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Livewire\Public\Browse;
+use App\Models\Property;
+use Livewire\Livewire;
+
+test('only published properties are listed', function () {
+    Property::factory()->published()->create(['title' => 'Published One']);
+    Property::factory()->draft()->create(['title' => 'Draft One']);
+
+    Livewire::test(Browse::class)
+        ->assertSee('Published One')
+        ->assertDontSee('Draft One');
+});
+
+test('location filter narrows results', function () {
+    Property::factory()->published()->create(['title' => 'Lahore House', 'location' => 'Lahore']);
+    Property::factory()->published()->create(['title' => 'Karachi House', 'location' => 'Karachi']);
+
+    Livewire::test(Browse::class)
+        ->set('location', 'Lahore')
+        ->assertSee('Lahore House')
+        ->assertDontSee('Karachi House');
+});
+
+test('type filter narrows results', function () {
+    Property::factory()->published()->create(['title' => 'An Apartment', 'type' => 'apartment']);
+    Property::factory()->published()->create(['title' => 'A House', 'type' => 'house']);
+
+    Livewire::test(Browse::class)
+        ->set('type', 'house')
+        ->assertSee('A House')
+        ->assertDontSee('An Apartment');
+});
+
+test('price range filter narrows results', function () {
+    Property::factory()->published()->create(['title' => 'Cheap Place', 'price' => 1_000_000]);
+    Property::factory()->published()->create(['title' => 'Expensive Place', 'price' => 90_000_000]);
+
+    Livewire::test(Browse::class)
+        ->set('max_price', '5000000')
+        ->assertSee('Cheap Place')
+        ->assertDontSee('Expensive Place');
+});

--- a/tests/Feature/Public/HomeTest.php
+++ b/tests/Feature/Public/HomeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Livewire\Public\Home;
+use App\Models\Property;
+use Livewire\Livewire;
+
+test('only published properties appear in recently listed', function () {
+    Property::factory()->published()->create(['title' => 'Published One']);
+    Property::factory()->draft()->create(['title' => 'Draft One']);
+
+    Livewire::test(Home::class)
+        ->assertSee('Published One')
+        ->assertDontSee('Draft One');
+});
+
+test('shows an empty state when nothing is published', function () {
+    Property::factory()->draft()->create();
+
+    Livewire::test(Home::class)
+        ->assertSee('No properties are published yet');
+});


### PR DESCRIPTION
## Summary
Syncs `develop` to `main`, bringing in #26:
- Public home (`/`) and browse (`/properties`) pages with live location/type/price filtering, backed by a shared `PropertyService`.
- Frontend rebrand to "SkyProperty - SP" with a green/white theme and a zameen.com-inspired category tab header.
- Fixes a real bug: `Property::details` had no array cast and was silently corrupting to the string `"Array"` on save.

Already reviewed and merged into develop in #26; this is a routine sync, no new changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)