### PR TITLE
Fix property card agency attribution and brand-name duplication

### DIFF
--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -30,6 +30,19 @@ class Property extends Model
         return $this->hasMany(Listing::class);
     }
 
+    /**
+     * The listing that should represent this property publicly: the most
+     * recently owner-approved one that isn't archived.
+     */
+    public function activeListing(): ?Listing
+    {
+        return $this->listings
+            ->where('user_approved', true)
+            ->whereNotIn('status', ['archived'])
+            ->sortByDesc('approved_at')
+            ->first();
+    }
+
     public function media()
     {
         return $this->hasMany(PropertyMedia::class);

--- a/resources/views/components/brand-logo.blade.php
+++ b/resources/views/components/brand-logo.blade.php
@@ -1,4 +1,14 @@
+@php
+    $appName = config('app.name', 'SkyProperty - SP');
+    [$brandName, $brandTag] = str_contains($appName, ' - ')
+        ? explode(' - ', $appName, 2)
+        : [$appName, null];
+@endphp
+
 <a href="{{ route('home') }}" class="flex items-baseline gap-1.5">
-    <span class="text-lg font-bold text-green-700">SkyProperty</span>
-    <span class="rounded bg-green-700 px-1 py-0.5 text-[10px] font-bold leading-none text-white">SP</span>
+    <span class="text-lg font-bold text-green-700">{{ $brandName }}</span>
+
+    @if ($brandTag)
+        <span class="rounded bg-green-700 px-1 py-0.5 text-[10px] font-bold leading-none text-white">{{ $brandTag }}</span>
+    @endif
 </a>

--- a/resources/views/components/property-card.blade.php
+++ b/resources/views/components/property-card.blade.php
@@ -44,7 +44,7 @@
             <p class="text-sm text-gray-500">{{ $details->join(' · ') }}</p>
         @endif
 
-        @php($agency = $property->listings->first()?->agency)
+        @php($agency = $property->activeListing()?->agency)
         @if ($agency)
             <p class="text-xs text-gray-400">Listed by {{ $agency->name }}</p>
         @endif

--- a/tests/Feature/PropertyActiveListingTest.php
+++ b/tests/Feature/PropertyActiveListingTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Models\Agency;
+use App\Models\Listing;
+use App\Models\Property;
+
+test('active listing ignores unapproved listings', function () {
+    $property = Property::factory()->create();
+
+    Listing::factory()->create([
+        'property_id' => $property->id,
+        'user_approved' => null,
+        'status' => 'pending',
+    ]);
+
+    expect($property->activeListing())->toBeNull();
+});
+
+test('active listing ignores archived listings even if approved', function () {
+    $property = Property::factory()->create();
+
+    Listing::factory()->create([
+        'property_id' => $property->id,
+        'user_approved' => true,
+        'status' => 'archived',
+        'approved_at' => now(),
+    ]);
+
+    expect($property->activeListing())->toBeNull();
+});
+
+test('active listing picks the most recently approved listing', function () {
+    $property = Property::factory()->create();
+    $older = Agency::factory()->create();
+    $newer = Agency::factory()->create();
+
+    Listing::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $older->id,
+        'user_approved' => true,
+        'status' => 'available',
+        'approved_at' => now()->subDay(),
+    ]);
+
+    Listing::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $newer->id,
+        'user_approved' => true,
+        'status' => 'available',
+        'approved_at' => now(),
+    ]);
+
+    expect($property->activeListing()->agency_id)->toBe($newer->id);
+});


### PR DESCRIPTION
## Summary
Fixes the two findings from the #26 review:

- **Agency attribution**: `Property::activeListing()` now picks the most recently owner-approved (`user_approved = true`), non-archived listing instead of `listings->first()`. Previously a card could show whichever listing came first in an unordered relation — including a rejected or still-pending one — as if it were the authoritative agency for that property.
- **Brand-name duplication**: `<x-brand-logo>` now derives its text from `config('app.name')` (splitting on `' - '` for the name/tag pair) instead of hardcoding `"SkyProperty"`/`"SP"`, matching how every `<title>` tag already resolves the app name. Verified by temporarily changing `APP_NAME` and confirming the header updates — it does.

## Test plan
- [x] New `PropertyActiveListingTest` — covers unapproved listings being ignored, archived-but-approved listings being ignored, and picking the most recently approved listing when multiple qualify
- [x] `php artisan test` — 24 passed
- [x] `./vendor/bin/pint --test` clean on changed files
- [x] Verified live: checked real seeded data (all listings are currently unapproved) and confirmed the card now correctly shows no agency line instead of an incorrect one; temporarily swapped `APP_NAME` in `.env` and confirmed the header logo text changes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)