### PR TITLE
Add My Properties dashboard

### DIFF
--- a/app/Http/Controllers/Api/PropertyController.php
+++ b/app/Http/Controllers/Api/PropertyController.php
@@ -39,8 +39,7 @@ class PropertyController extends Controller
      */
     public function mine(Request $request)
     {
-        $properties = $request->user()->properties()
-            ->with(['listings.agency', 'media'])
+        $properties = $this->properties->mine($request->user())
             ->latest()
             ->paginate(10);
 
@@ -59,6 +58,7 @@ class PropertyController extends Controller
             'currency' => 'nullable|string|max:10',
             'price' => 'nullable|numeric|min:0',
             'location' => 'nullable|string|max:255',
+            'available_from' => 'nullable|date',
             'details' => 'nullable|array',
         ]);
 
@@ -86,6 +86,7 @@ class PropertyController extends Controller
             'price' => 'nullable|numeric|min:0',
             'status' => 'nullable|in:draft,published,archived',
             'location' => 'nullable|string|max:255',
+            'available_from' => 'nullable|date',
             'details' => 'nullable|array',
         ]);
 

--- a/app/Http/Controllers/Api/PropertyController.php
+++ b/app/Http/Controllers/Api/PropertyController.php
@@ -40,6 +40,7 @@ class PropertyController extends Controller
     public function mine(Request $request)
     {
         $properties = $this->properties->mine($request->user())
+            ->with(['listings.agency', 'media'])
             ->latest()
             ->paginate(10);
 

--- a/app/Livewire/Dashboard/MyProperties.php
+++ b/app/Livewire/Dashboard/MyProperties.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Livewire\Dashboard;
+
+use App\Services\PropertyService;
+use Livewire\Attributes\Layout;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+#[Layout('layouts.app')]
+class MyProperties extends Component
+{
+    use WithPagination;
+
+    #[Url]
+    public string $tab = 'active';
+
+    public function setTab(string $tab): void
+    {
+        $this->tab = $tab;
+        $this->resetPage();
+    }
+
+    public function delete(int $propertyId): void
+    {
+        auth()->user()->properties()->findOrFail($propertyId)->delete();
+    }
+
+    public function render()
+    {
+        $properties = app(PropertyService::class);
+
+        $query = $properties->byTab($properties->mine(auth()->user()), $this->tab);
+
+        return view('livewire.dashboard.my-properties', [
+            'properties' => $query->latest()->paginate(9),
+        ]);
+    }
+}

--- a/app/Livewire/Dashboard/PropertyForm.php
+++ b/app/Livewire/Dashboard/PropertyForm.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Livewire\Dashboard;
+
+use App\Models\Property;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('layouts.app')]
+class PropertyForm extends Component
+{
+    public ?Property $property = null;
+
+    public string $title = '';
+
+    public string $description = '';
+
+    public string $type = '';
+
+    public string $currency = 'PKR';
+
+    public string $price = '';
+
+    public string $location = '';
+
+    public string $available_from = '';
+
+    public string $status = 'draft';
+
+    public string $bedrooms = '';
+
+    public string $bathrooms = '';
+
+    public string $area_sqft = '';
+
+    public function mount(?int $id = null): void
+    {
+        if (! $id) {
+            return;
+        }
+
+        $this->property = auth()->user()->properties()->findOrFail($id);
+
+        $this->title = $this->property->title;
+        $this->description = (string) $this->property->description;
+        $this->type = (string) $this->property->type;
+        $this->currency = $this->property->currency ?? 'PKR';
+        $this->price = (string) $this->property->price;
+        $this->location = (string) $this->property->location;
+        $this->available_from = $this->property->available_from?->format('Y-m-d') ?? '';
+        $this->status = $this->property->status;
+        $this->bedrooms = (string) ($this->property->details['bedrooms'] ?? '');
+        $this->bathrooms = (string) ($this->property->details['bathrooms'] ?? '');
+        $this->area_sqft = (string) ($this->property->details['area_sqft'] ?? '');
+    }
+
+    public function save(): void
+    {
+        $rules = [
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'type' => 'nullable|in:apartment,house,land,commercial',
+            'currency' => 'nullable|string|max:10',
+            'price' => 'nullable|numeric|min:0',
+            'location' => 'nullable|string|max:255',
+            'available_from' => 'nullable|date',
+            'bedrooms' => 'nullable|integer|min:0',
+            'bathrooms' => 'nullable|integer|min:0',
+            'area_sqft' => 'nullable|integer|min:0',
+        ];
+
+        if ($this->property) {
+            $rules['status'] = 'required|in:draft,published,archived';
+        }
+
+        $validated = $this->validate($rules);
+
+        $attributes = [
+            'title' => $validated['title'],
+            'description' => $validated['description'] ?: null,
+            'type' => $validated['type'] ?: null,
+            'currency' => $validated['currency'] ?: null,
+            'price' => $validated['price'] !== '' && $validated['price'] !== null ? $validated['price'] : null,
+            'location' => $validated['location'] ?: null,
+            'available_from' => $validated['available_from'] ?: null,
+            'details' => array_filter([
+                'bedrooms' => $validated['bedrooms'] !== '' && $validated['bedrooms'] !== null ? (int) $validated['bedrooms'] : null,
+                'bathrooms' => $validated['bathrooms'] !== '' && $validated['bathrooms'] !== null ? (int) $validated['bathrooms'] : null,
+                'area_sqft' => $validated['area_sqft'] !== '' && $validated['area_sqft'] !== null ? (int) $validated['area_sqft'] : null,
+            ], fn ($value) => $value !== null),
+        ];
+
+        if ($this->property) {
+            $attributes['status'] = $validated['status'];
+            $this->property->update($attributes);
+        } else {
+            auth()->user()->properties()->create($attributes);
+        }
+
+        $this->redirect(route('dashboard.properties.index'), navigate: true);
+    }
+
+    public function render()
+    {
+        return view('livewire.dashboard.property-form');
+    }
+}

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -17,6 +17,7 @@ class Property extends Model
         return [
             'details' => 'array',
             'price' => 'decimal:2',
+            'available_from' => 'date',
         ];
     }
 

--- a/app/Services/PropertyService.php
+++ b/app/Services/PropertyService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\Property;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 
 class PropertyService
@@ -15,6 +16,26 @@ class PropertyService
         return Property::query()
             ->where('status', 'published')
             ->with(['listings.agency', 'media']);
+    }
+
+    /**
+     * Base query for a user's own properties, any status.
+     */
+    public function mine(User $user): Builder
+    {
+        return Property::query()
+            ->where('user_id', $user->id)
+            ->with(['listings.agency', 'media']);
+    }
+
+    /**
+     * Scope a "mine" query to the Active or Archived dashboard tab.
+     */
+    public function byTab(Builder $query, string $tab): Builder
+    {
+        return $tab === 'archived'
+            ? $query->where('status', 'archived')
+            : $query->where('status', '!=', 'archived');
     }
 
     /**

--- a/app/Services/PropertyService.php
+++ b/app/Services/PropertyService.php
@@ -19,13 +19,12 @@ class PropertyService
     }
 
     /**
-     * Base query for a user's own properties, any status.
+     * Base query for a user's own properties, any status. Callers should
+     * eager-load whichever relations their view actually needs.
      */
     public function mine(User $user): Builder
     {
-        return Property::query()
-            ->where('user_id', $user->id)
-            ->with(['listings.agency', 'media']);
+        return Property::query()->where('user_id', $user->id);
     }
 
     /**

--- a/database/migrations/2026_08_06_120925_add_available_from_to_properties_table.php
+++ b/database/migrations/2026_08_06_120925_add_available_from_to_properties_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('properties', function (Blueprint $table) {
+            $table->date('available_from')->nullable()->after('location');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('properties', function (Blueprint $table) {
+            $table->dropColumn('available_from');
+        });
+    }
+};

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -16,6 +16,7 @@
 
                 <nav class="flex items-center gap-4 text-sm">
                     <a href="{{ route('dashboard') }}" class="text-gray-600 hover:text-green-700">Dashboard</a>
+                    <a href="{{ route('dashboard.properties.index') }}" class="text-gray-600 hover:text-green-700">My Properties</a>
                     <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-green-700">Browse properties</a>
 
                     <form method="POST" action="{{ route('logout') }}">

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -1,4 +1,7 @@
 <div>
     <h1 class="text-2xl font-semibold text-gray-900">Welcome, {{ auth()->user()->name }}</h1>
-    <p class="mt-2 text-gray-600">Your dashboard is coming soon.</p>
+    <p class="mt-2 text-gray-600">
+        Manage your properties from
+        <a href="{{ route('dashboard.properties.index') }}" class="font-medium text-green-700 hover:text-green-800">My Properties</a>.
+    </p>
 </div>

--- a/resources/views/livewire/dashboard/my-properties.blade.php
+++ b/resources/views/livewire/dashboard/my-properties.blade.php
@@ -1,0 +1,87 @@
+<div class="space-y-6">
+    <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold text-gray-900">My Properties</h1>
+        <a href="{{ route('dashboard.properties.create') }}" class="rounded-md bg-green-700 px-4 py-2 text-sm font-semibold text-white hover:bg-green-800">
+            Add Property
+        </a>
+    </div>
+
+    <div class="flex gap-6 border-b border-gray-200 text-sm font-medium">
+        <button
+            type="button"
+            wire:click="setTab('active')"
+            class="border-b-2 px-1 py-2 {{ $tab === 'active' ? 'border-green-700 text-green-700' : 'border-transparent text-gray-500 hover:text-gray-700' }}"
+        >
+            Active
+        </button>
+        <button
+            type="button"
+            wire:click="setTab('archived')"
+            class="border-b-2 px-1 py-2 {{ $tab === 'archived' ? 'border-green-700 text-green-700' : 'border-transparent text-gray-500 hover:text-gray-700' }}"
+        >
+            Archived
+        </button>
+    </div>
+
+    @if ($properties->isEmpty())
+        <p class="text-gray-500">
+            @if ($tab === 'archived')
+                No archived properties.
+            @else
+                You haven't added any properties yet.
+            @endif
+        </p>
+    @else
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+            <table class="w-full text-left text-sm">
+                <thead class="border-b border-gray-200 bg-gray-50 text-gray-500">
+                    <tr>
+                        <th class="px-4 py-3">Property</th>
+                        <th class="px-4 py-3">Status</th>
+                        <th class="px-4 py-3">Price</th>
+                        <th class="px-4 py-3"></th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    @foreach ($properties as $property)
+                        <tr wire:key="property-{{ $property->id }}">
+                            <td class="px-4 py-3">
+                                <div class="font-medium text-gray-900">{{ $property->title }}</div>
+                                <div class="text-gray-500">{{ $property->location }}</div>
+                            </td>
+                            <td class="px-4 py-3">
+                                <span class="rounded-full px-2 py-0.5 text-xs font-medium {{ match ($property->status) {
+                                    'published' => 'bg-green-50 text-green-700',
+                                    'archived' => 'bg-gray-100 text-gray-600',
+                                    default => 'bg-amber-50 text-amber-700',
+                                } }}">
+                                    {{ ucfirst($property->status) }}
+                                </span>
+                            </td>
+                            <td class="px-4 py-3">
+                                @if ($property->price)
+                                    {{ $property->currency ?? 'PKR' }} {{ number_format($property->price) }}
+                                @else
+                                    <span class="text-gray-400">&mdash;</span>
+                                @endif
+                            </td>
+                            <td class="px-4 py-3 text-right">
+                                <a href="{{ route('dashboard.properties.edit', $property->id) }}" class="text-green-700 hover:text-green-800">Edit</a>
+                                <button
+                                    type="button"
+                                    wire:click="delete({{ $property->id }})"
+                                    wire:confirm="Delete this property? This cannot be undone."
+                                    class="ml-3 text-red-600 hover:text-red-800"
+                                >
+                                    Delete
+                                </button>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+
+        {{ $properties->links() }}
+    @endif
+</div>

--- a/resources/views/livewire/dashboard/property-form.blade.php
+++ b/resources/views/livewire/dashboard/property-form.blade.php
@@ -1,0 +1,101 @@
+<div class="max-w-2xl space-y-6">
+    <h1 class="text-2xl font-semibold text-gray-900">{{ $property ? 'Edit Property' : 'Add Property' }}</h1>
+
+    <form wire:submit="save" class="space-y-4">
+        <div>
+            <x-input-label for="title" value="Title" />
+            <x-text-input wire:model="title" id="title" type="text" />
+            <x-input-error :messages="$errors->get('title')" class="mt-2" />
+        </div>
+
+        <div>
+            <x-input-label for="description" value="Description" />
+            <textarea
+                wire:model="description"
+                id="description"
+                rows="4"
+                class="block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm"
+            ></textarea>
+            <x-input-error :messages="$errors->get('description')" class="mt-2" />
+        </div>
+
+        <div class="grid grid-cols-2 gap-4">
+            <div>
+                <x-input-label for="type" value="Type" />
+                <select wire:model="type" id="type" class="block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm">
+                    <option value="">Select type</option>
+                    <option value="apartment">Apartment</option>
+                    <option value="house">House</option>
+                    <option value="land">Land</option>
+                    <option value="commercial">Commercial</option>
+                </select>
+                <x-input-error :messages="$errors->get('type')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="location" value="Location" />
+                <x-text-input wire:model="location" id="location" type="text" />
+                <x-input-error :messages="$errors->get('location')" class="mt-2" />
+            </div>
+        </div>
+
+        <div class="grid grid-cols-2 gap-4">
+            <div>
+                <x-input-label for="currency" value="Currency" />
+                <x-text-input wire:model="currency" id="currency" type="text" />
+                <x-input-error :messages="$errors->get('currency')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="price" value="Price" />
+                <x-text-input wire:model="price" id="price" type="number" min="0" step="0.01" />
+                <x-input-error :messages="$errors->get('price')" class="mt-2" />
+            </div>
+        </div>
+
+        <div>
+            <x-input-label for="available_from" value="Available from" />
+            <x-text-input wire:model="available_from" id="available_from" type="date" />
+            <x-input-error :messages="$errors->get('available_from')" class="mt-2" />
+        </div>
+
+        <div class="grid grid-cols-3 gap-4">
+            <div>
+                <x-input-label for="bedrooms" value="Bedrooms" />
+                <x-text-input wire:model="bedrooms" id="bedrooms" type="number" min="0" />
+                <x-input-error :messages="$errors->get('bedrooms')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="bathrooms" value="Bathrooms" />
+                <x-text-input wire:model="bathrooms" id="bathrooms" type="number" min="0" />
+                <x-input-error :messages="$errors->get('bathrooms')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="area_sqft" value="Area (sqft)" />
+                <x-text-input wire:model="area_sqft" id="area_sqft" type="number" min="0" />
+                <x-input-error :messages="$errors->get('area_sqft')" class="mt-2" />
+            </div>
+        </div>
+
+        @if ($property)
+            <div>
+                <x-input-label for="status" value="Status" />
+                <select wire:model="status" id="status" class="block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm">
+                    <option value="draft">Draft</option>
+                    <option value="published">Published</option>
+                    <option value="archived">Archived</option>
+                </select>
+                <x-input-error :messages="$errors->get('status')" class="mt-2" />
+            </div>
+        @endif
+
+        <div class="flex items-center gap-4">
+            <button type="submit" class="rounded-md bg-green-700 px-6 py-2 text-sm font-semibold text-white hover:bg-green-800">
+                {{ $property ? 'Save changes' : 'Add property' }}
+            </button>
+            <a href="{{ route('dashboard.properties.index') }}" class="text-sm text-gray-600 hover:text-green-700">Cancel</a>
+        </div>
+    </form>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,12 +1,20 @@
 <?php
 
 use App\Livewire\Dashboard;
+use App\Livewire\Dashboard\MyProperties;
+use App\Livewire\Dashboard\PropertyForm;
 use App\Livewire\Public\Browse;
 use App\Livewire\Public\Home;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', Home::class)->name('home');
 Route::get('/properties', Browse::class)->name('properties.index');
+
+Route::middleware('auth')->prefix('dashboard')->name('dashboard.')->group(function () {
+    Route::get('/properties', MyProperties::class)->name('properties.index');
+    Route::get('/properties/create', PropertyForm::class)->name('properties.create');
+    Route::get('/properties/{id}/edit', PropertyForm::class)->name('properties.edit');
+});
 
 Route::get('/dashboard', Dashboard::class)
     ->middleware('auth')

--- a/tests/Feature/Dashboard/MyPropertiesTest.php
+++ b/tests/Feature/Dashboard/MyPropertiesTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Livewire\Dashboard\MyProperties;
+use App\Models\Property;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('guests are redirected to login', function () {
+    $this->get(route('dashboard.properties.index'))->assertRedirect(route('login'));
+});
+
+test('only the authenticated user\'s own properties are listed', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+
+    Property::factory()->published()->create(['user_id' => $owner->id, 'title' => 'My Place']);
+    Property::factory()->published()->create(['user_id' => $other->id, 'title' => 'Their Place']);
+
+    Livewire::actingAs($owner)
+        ->test(MyProperties::class)
+        ->assertSee('My Place')
+        ->assertDontSee('Their Place');
+});
+
+test('active tab excludes archived properties', function () {
+    $user = User::factory()->create();
+
+    Property::factory()->draft()->create(['user_id' => $user->id, 'title' => 'Draft Place']);
+    Property::factory()->create(['user_id' => $user->id, 'status' => 'archived', 'title' => 'Archived Place']);
+
+    Livewire::actingAs($user)
+        ->test(MyProperties::class)
+        ->assertSee('Draft Place')
+        ->assertDontSee('Archived Place');
+});
+
+test('archived tab only shows archived properties', function () {
+    $user = User::factory()->create();
+
+    Property::factory()->draft()->create(['user_id' => $user->id, 'title' => 'Draft Place']);
+    Property::factory()->create(['user_id' => $user->id, 'status' => 'archived', 'title' => 'Archived Place']);
+
+    Livewire::actingAs($user)
+        ->test(MyProperties::class)
+        ->call('setTab', 'archived')
+        ->assertSee('Archived Place')
+        ->assertDontSee('Draft Place');
+});
+
+test('a user can delete their own property', function () {
+    $user = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $user->id]);
+
+    Livewire::actingAs($user)
+        ->test(MyProperties::class)
+        ->call('delete', $property->id);
+
+    expect(Property::find($property->id))->toBeNull();
+});
+
+test('a user cannot delete another user\'s property', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+
+    $this->actingAs($intruder);
+
+    expect(fn () => Livewire::test(MyProperties::class)->call('delete', $property->id))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    expect(Property::find($property->id))->not->toBeNull();
+});

--- a/tests/Feature/Dashboard/PropertyFormTest.php
+++ b/tests/Feature/Dashboard/PropertyFormTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Livewire\Dashboard\PropertyForm;
+use App\Models\Property;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('a user can create a property', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(PropertyForm::class)
+        ->set('title', 'Sunny Apartment')
+        ->set('type', 'apartment')
+        ->set('price', '5000000')
+        ->set('location', 'Lahore')
+        ->set('available_from', '2026-09-01')
+        ->set('bedrooms', '2')
+        ->call('save')
+        ->assertRedirect(route('dashboard.properties.index'));
+
+    $property = Property::where('title', 'Sunny Apartment')->first();
+
+    expect($property)->not->toBeNull();
+    expect($property->user_id)->toBe($user->id);
+    expect($property->status)->toBe('draft');
+    expect($property->available_from->format('Y-m-d'))->toBe('2026-09-01');
+    expect($property->details['bedrooms'])->toBe(2);
+});
+
+test('status cannot be set on create', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(PropertyForm::class)
+        ->set('title', 'Some Place')
+        ->set('status', 'published')
+        ->call('save');
+
+    $property = Property::where('title', 'Some Place')->first();
+
+    expect($property->status)->toBe('draft');
+});
+
+test('title is required', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(PropertyForm::class)
+        ->set('title', '')
+        ->call('save')
+        ->assertHasErrors(['title' => 'required']);
+});
+
+test('editing loads the owner\'s existing property data', function () {
+    $user = User::factory()->create();
+    $property = Property::factory()->create([
+        'user_id' => $user->id,
+        'title' => 'Existing Place',
+        'status' => 'published',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(PropertyForm::class, ['id' => $property->id])
+        ->assertSet('title', 'Existing Place')
+        ->assertSet('status', 'published');
+});
+
+test('a user cannot edit another user\'s property', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+
+    $this->actingAs($intruder);
+
+    expect(fn () => Livewire::test(PropertyForm::class, ['id' => $property->id]))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+});
+
+test('editing can change the status', function () {
+    $user = User::factory()->create();
+    $property = Property::factory()->draft()->create(['user_id' => $user->id]);
+
+    Livewire::actingAs($user)
+        ->test(PropertyForm::class, ['id' => $property->id])
+        ->set('status', 'published')
+        ->call('save');
+
+    expect($property->fresh()->status)->toBe('published');
+});


### PR DESCRIPTION
## Summary
New authenticated `/dashboard/properties` section — list, create, edit, delete for the user's own properties. Layout (Active/Archived tabs) confirmed against the Figma "Property Menu" screen via read-only inspection only (search + Properties/Preview panels) — no changes made to the Figma file.

- **MyProperties** — lists the user's own properties, any status, tabbed Active (draft+published) vs Archived, with Edit/Delete per row.
- **PropertyForm** — one component for both create and edit. Status is only settable when editing, never on create, matching the existing API's `store()`/`update()` asymmetry rather than inventing a new dashboard-only rule.
- **`PropertyService::mine()`** extracted and shared by both the API's `mine()` endpoint and this new dashboard, instead of a third duplicate "user's own properties" query.
- **`Property.available_from`** (migration + cast) — new field, based on the "Editing Date Available" screen found in the Figma deep-dive; didn't exist anywhere in the schema before.

## Bug caught while writing tests
`PropertyService::mine()` was declared to return `Builder`, but `$user->properties()` returns `HasMany` — not type-compatible with a strict `Builder` return type. This would have been a hard `TypeError` on every single call (API and dashboard alike). Fixed by building the query explicitly against `Property::query()->where('user_id', ...)`, matching `published()`'s existing style — confirmed by the tests failing before the fix and passing after.

## Test plan
- [x] `php artisan test` — 33 passed (12 new: ownership scoping, Active/Archived tabs, delete ownership enforcement, create/edit validation, status-only-on-edit rule, cross-user 404s)
- [x] `./vendor/bin/pint --test` clean on all changed files
- [x] Verified live: logged in, created a property (no status field shown), confirmed it defaulted to draft, edited it to Published, confirmed it then appeared in public Browse, confirmed `available_from` round-trips correctly through the edit form

🤖 Generated with [Claude Code](https://claude.com/claude-code)