### PR TITLE
Add public property detail page

### DIFF
--- a/app/Livewire/Public/Show.php
+++ b/app/Livewire/Public/Show.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Livewire\Public;
+
+use App\Models\Property;
+use App\Services\PropertyService;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('layouts.public')]
+class Show extends Component
+{
+    public Property $property;
+
+    public function mount($id): void
+    {
+        $this->property = app(PropertyService::class)->published()->findOrFail($id);
+    }
+
+    public function render()
+    {
+        return view('livewire.public.show');
+    }
+}

--- a/resources/views/components/property-card.blade.php
+++ b/resources/views/components/property-card.blade.php
@@ -1,6 +1,6 @@
 @props(['property'])
 
-<article class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+<a href="{{ route('properties.show', $property->id) }}" class="block overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition hover:border-green-700 hover:shadow-md">
     <div class="aspect-video bg-gray-100">
         @php($image = $property->media->firstWhere('type', 'image'))
         @if ($image)
@@ -28,25 +28,14 @@
         @endif
 
         <p class="text-lg font-semibold text-gray-900">
-            @if ($property->price)
-                {{ $property->currency ?? 'PKR' }} {{ number_format($property->price) }}
-            @else
-                Price on request
-            @endif
+            <x-property-price :property="$property" />
         </p>
 
-        @php($details = collect([
-            isset($property->details['bedrooms']) ? $property->details['bedrooms'].' bed' : null,
-            isset($property->details['bathrooms']) ? $property->details['bathrooms'].' bath' : null,
-            isset($property->details['area_sqft']) ? $property->details['area_sqft'].' sqft' : null,
-        ])->filter())
-        @if ($details->isNotEmpty())
-            <p class="text-sm text-gray-500">{{ $details->join(' · ') }}</p>
-        @endif
+        <x-property-details-summary :property="$property" />
 
         @php($agency = $property->activeListing()?->agency)
         @if ($agency)
             <p class="text-xs text-gray-400">Listed by {{ $agency->name }}</p>
         @endif
     </div>
-</article>
+</a>

--- a/resources/views/components/property-details-summary.blade.php
+++ b/resources/views/components/property-details-summary.blade.php
@@ -1,0 +1,11 @@
+@props(['property'])
+
+@php($items = collect([
+    isset($property->details['bedrooms']) ? $property->details['bedrooms'].' bed' : null,
+    isset($property->details['bathrooms']) ? $property->details['bathrooms'].' bath' : null,
+    isset($property->details['area_sqft']) ? $property->details['area_sqft'].' sqft' : null,
+])->filter())
+
+@if ($items->isNotEmpty())
+    <p {{ $attributes->merge(['class' => 'text-sm text-gray-500']) }}>{{ $items->join(' · ') }}</p>
+@endif

--- a/resources/views/components/property-price.blade.php
+++ b/resources/views/components/property-price.blade.php
@@ -1,0 +1,9 @@
+@props(['property'])
+
+<span {{ $attributes }}>
+    @if ($property->price)
+        {{ $property->currency ?? 'PKR' }} {{ number_format($property->price) }}
+    @else
+        Price on request
+    @endif
+</span>

--- a/resources/views/livewire/public/show.blade.php
+++ b/resources/views/livewire/public/show.blade.php
@@ -1,0 +1,85 @@
+<div class="space-y-8">
+    <a href="{{ route('properties.index') }}" class="text-sm text-gray-600 hover:text-green-700">&larr; Back to browse</a>
+
+    @php($images = $property->media->where('type', 'image')->values())
+
+    <div x-data="{ active: 0 }" class="space-y-3">
+        <div class="aspect-video overflow-hidden rounded-lg bg-gray-100">
+            @if ($images->isNotEmpty())
+                @foreach ($images as $index => $image)
+                    <img
+                        x-show="active === {{ $index }}"
+                        src="{{ asset('storage/'.$image->path) }}"
+                        alt="{{ $property->title }}"
+                        class="h-full w-full object-cover"
+                    >
+                @endforeach
+            @else
+                <div class="flex h-full w-full items-center justify-center text-sm text-gray-400">
+                    No image
+                </div>
+            @endif
+        </div>
+
+        @if ($images->count() > 1)
+            <div class="flex gap-2 overflow-x-auto">
+                @foreach ($images as $index => $image)
+                    <button
+                        type="button"
+                        @click="active = {{ $index }}"
+                        :class="active === {{ $index }} ? 'ring-2 ring-green-700' : 'ring-1 ring-gray-200'"
+                        class="h-16 w-24 shrink-0 overflow-hidden rounded-md"
+                    >
+                        <img src="{{ asset('storage/'.$image->path) }}" alt="" class="h-full w-full object-cover">
+                    </button>
+                @endforeach
+            </div>
+        @endif
+    </div>
+
+    <div class="grid gap-8 lg:grid-cols-3">
+        <div class="space-y-4 lg:col-span-2">
+            <div class="flex items-start justify-between gap-2">
+                <h1 class="text-2xl font-semibold text-gray-900">{{ $property->title }}</h1>
+
+                @if ($property->type)
+                    <span class="shrink-0 rounded-full bg-green-50 px-3 py-1 text-sm font-medium text-green-700">
+                        {{ ucfirst($property->type) }}
+                    </span>
+                @endif
+            </div>
+
+            @if ($property->location)
+                <p class="text-gray-500">{{ $property->location }}</p>
+            @endif
+
+            <x-property-details-summary :property="$property" class="text-base text-gray-700" />
+
+            @if ($property->description)
+                <p class="whitespace-pre-line pt-4 text-gray-700">{{ $property->description }}</p>
+            @endif
+        </div>
+
+        <div class="space-y-4 rounded-lg border border-gray-200 bg-white p-6">
+            <p class="text-2xl font-semibold text-gray-900">
+                <x-property-price :property="$property" />
+            </p>
+
+            @php($agency = $property->activeListing()?->agency)
+            @if ($agency)
+                <div class="space-y-1 border-t border-gray-100 pt-4">
+                    <p class="text-sm font-medium text-gray-900">Listed by</p>
+                    <p class="text-sm text-gray-700">{{ $agency->name }}</p>
+
+                    @if ($agency->phone)
+                        <p class="text-sm text-gray-500">{{ $agency->phone }}</p>
+                    @endif
+
+                    @if ($agency->email)
+                        <p class="text-sm text-gray-500">{{ $agency->email }}</p>
+                    @endif
+                </div>
+            @endif
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,10 +3,12 @@
 use App\Livewire\Dashboard;
 use App\Livewire\Public\Browse;
 use App\Livewire\Public\Home;
+use App\Livewire\Public\Show;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', Home::class)->name('home');
 Route::get('/properties', Browse::class)->name('properties.index');
+Route::get('/properties/{id}', Show::class)->name('properties.show');
 
 Route::get('/dashboard', Dashboard::class)
     ->middleware('auth')

--- a/tests/Feature/Public/ShowTest.php
+++ b/tests/Feature/Public/ShowTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Livewire\Public\Show;
+use App\Models\Property;
+use App\Models\PropertyMedia;
+use Livewire\Livewire;
+
+test('published property detail page renders its content', function () {
+    $property = Property::factory()->published()->create([
+        'title' => 'Lovely Cottage',
+        'description' => 'A lovely little cottage by the lake.',
+    ]);
+
+    Livewire::test(Show::class, ['id' => $property->id])
+        ->assertSee('Lovely Cottage')
+        ->assertSee('A lovely little cottage by the lake.');
+});
+
+test('draft property detail page 404s', function () {
+    $draft = Property::factory()->draft()->create();
+
+    $this->get("/properties/{$draft->id}")->assertNotFound();
+});
+
+test('published property detail page is reachable over http', function () {
+    $property = Property::factory()->published()->create();
+
+    $this->get("/properties/{$property->id}")->assertOk();
+});
+
+test('gallery indices stay sequential when a non-image media item sorts first', function () {
+    $property = Property::factory()->published()->create();
+
+    // A non-image item with a lower sort position would leave gaps in the
+    // media collection's keys if the image list isn't re-indexed, breaking
+    // the gallery's active-index toggle (x-show="active === N").
+    PropertyMedia::factory()->create(['property_id' => $property->id, 'type' => 'video', 'path' => 'videos/tour.mp4', 'sort_order' => 0]);
+    PropertyMedia::factory()->create(['property_id' => $property->id, 'type' => 'image', 'path' => 'images/one.jpg', 'sort_order' => 1]);
+    PropertyMedia::factory()->create(['property_id' => $property->id, 'type' => 'image', 'path' => 'images/two.jpg', 'sort_order' => 2]);
+
+    Livewire::test(Show::class, ['id' => $property->id])
+        ->assertSeeHtml('active === 0')
+        ->assertSeeHtml('active === 1')
+        ->assertDontSeeHtml('active === 2');
+});


### PR DESCRIPTION
## Summary
(Recreated from #29, which GitHub auto-closed when `fix/property-card-agency-and-brand-name`'s branch was deleted after merging #28 — the branch and commit are unchanged, just re-targeted at `develop` now that #28 is merged.)

- Adds `/properties/{id}` (`App\Livewire\Public\Show`) with an image gallery, description, bed/bath/sqft summary, and the active listing's agency contact info.
- Property cards on Home/Browse are now real links to this page instead of static.
- Extracted `<x-property-price>` and `<x-property-details-summary>` out of the card component so the detail page reuses the same formatting instead of duplicating it.

## Bug caught and fixed during verification
Eloquent's `Collection::where()` preserves original array keys instead of reindexing. `$property->media->where('type', 'image')` could leave non-sequential keys whenever a non-image item like a video sorted first. The gallery's Alpine `x-show="active === {{ $index }}"` toggle compares against `active: 0`, so with keys starting at 1 instead of 0, no image ever rendered at all, not even the first one. Fixed with `->values()` to reindex, and added a regression test that asserts the indices stay `0, 1, 2, ...` — confirmed it fails without `->values()` and passes with it.

## Test plan
- [x] `php artisan test` — 28 passed
- [x] `./vendor/bin/pint --test` clean on changed files
- [x] Verified live: clicked from Browse card → detail page, gallery thumbnail switching (with real temp test images), draft property 404s, agency section correctly omitted when no listing is approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)