### PR TITLE
Sync develop to main: card/brand fixes, property detail page, My Properties dashboard

### DIFF
--- a/app/Http/Controllers/Api/PropertyController.php
+++ b/app/Http/Controllers/Api/PropertyController.php
@@ -39,8 +39,7 @@ class PropertyController extends Controller
      */
     public function mine(Request $request)
     {
-        $properties = $request->user()->properties()
-            ->with(['listings.agency', 'media'])
+        $properties = $this->properties->mine($request->user())
             ->latest()
             ->paginate(10);
 
@@ -59,6 +58,7 @@ class PropertyController extends Controller
             'currency' => 'nullable|string|max:10',
             'price' => 'nullable|numeric|min:0',
             'location' => 'nullable|string|max:255',
+            'available_from' => 'nullable|date',
             'details' => 'nullable|array',
         ]);
 
@@ -86,6 +86,7 @@ class PropertyController extends Controller
             'price' => 'nullable|numeric|min:0',
             'status' => 'nullable|in:draft,published,archived',
             'location' => 'nullable|string|max:255',
+            'available_from' => 'nullable|date',
             'details' => 'nullable|array',
         ]);
 

--- a/app/Http/Controllers/Api/PropertyController.php
+++ b/app/Http/Controllers/Api/PropertyController.php
@@ -40,6 +40,7 @@ class PropertyController extends Controller
     public function mine(Request $request)
     {
         $properties = $this->properties->mine($request->user())
+            ->with(['listings.agency', 'media'])
             ->latest()
             ->paginate(10);
 

--- a/app/Livewire/Dashboard/MyProperties.php
+++ b/app/Livewire/Dashboard/MyProperties.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Livewire\Dashboard;
+
+use App\Services\PropertyService;
+use Livewire\Attributes\Layout;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+#[Layout('layouts.app')]
+class MyProperties extends Component
+{
+    use WithPagination;
+
+    #[Url]
+    public string $tab = 'active';
+
+    public function setTab(string $tab): void
+    {
+        $this->tab = $tab;
+        $this->resetPage();
+    }
+
+    public function delete(int $propertyId): void
+    {
+        auth()->user()->properties()->findOrFail($propertyId)->delete();
+    }
+
+    public function render()
+    {
+        $properties = app(PropertyService::class);
+
+        $query = $properties->byTab($properties->mine(auth()->user()), $this->tab);
+
+        return view('livewire.dashboard.my-properties', [
+            'properties' => $query->latest()->paginate(9),
+        ]);
+    }
+}

--- a/app/Livewire/Dashboard/PropertyForm.php
+++ b/app/Livewire/Dashboard/PropertyForm.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Livewire\Dashboard;
+
+use App\Models\Property;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('layouts.app')]
+class PropertyForm extends Component
+{
+    public ?Property $property = null;
+
+    public string $title = '';
+
+    public string $description = '';
+
+    public string $type = '';
+
+    public string $currency = 'PKR';
+
+    public string $price = '';
+
+    public string $location = '';
+
+    public string $available_from = '';
+
+    public string $status = 'draft';
+
+    public string $bedrooms = '';
+
+    public string $bathrooms = '';
+
+    public string $area_sqft = '';
+
+    public function mount(?int $id = null): void
+    {
+        if (! $id) {
+            return;
+        }
+
+        $this->property = auth()->user()->properties()->findOrFail($id);
+
+        $this->title = $this->property->title;
+        $this->description = (string) $this->property->description;
+        $this->type = (string) $this->property->type;
+        $this->currency = $this->property->currency ?? 'PKR';
+        $this->price = (string) $this->property->price;
+        $this->location = (string) $this->property->location;
+        $this->available_from = $this->property->available_from?->format('Y-m-d') ?? '';
+        $this->status = $this->property->status;
+        $this->bedrooms = (string) ($this->property->details['bedrooms'] ?? '');
+        $this->bathrooms = (string) ($this->property->details['bathrooms'] ?? '');
+        $this->area_sqft = (string) ($this->property->details['area_sqft'] ?? '');
+    }
+
+    public function save(): void
+    {
+        $rules = [
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'type' => 'nullable|in:apartment,house,land,commercial',
+            'currency' => 'nullable|string|max:10',
+            'price' => 'nullable|numeric|min:0',
+            'location' => 'nullable|string|max:255',
+            'available_from' => 'nullable|date',
+            'bedrooms' => 'nullable|integer|min:0',
+            'bathrooms' => 'nullable|integer|min:0',
+            'area_sqft' => 'nullable|integer|min:0',
+        ];
+
+        if ($this->property) {
+            $rules['status'] = 'required|in:draft,published,archived';
+        }
+
+        $validated = $this->validate($rules);
+
+        $attributes = [
+            'title' => $validated['title'],
+            'description' => $validated['description'] ?: null,
+            'type' => $validated['type'] ?: null,
+            'currency' => $validated['currency'] ?: null,
+            'price' => $validated['price'] !== '' && $validated['price'] !== null ? $validated['price'] : null,
+            'location' => $validated['location'] ?: null,
+            'available_from' => $validated['available_from'] ?: null,
+            'details' => array_filter([
+                'bedrooms' => $validated['bedrooms'] !== '' && $validated['bedrooms'] !== null ? (int) $validated['bedrooms'] : null,
+                'bathrooms' => $validated['bathrooms'] !== '' && $validated['bathrooms'] !== null ? (int) $validated['bathrooms'] : null,
+                'area_sqft' => $validated['area_sqft'] !== '' && $validated['area_sqft'] !== null ? (int) $validated['area_sqft'] : null,
+            ], fn ($value) => $value !== null),
+        ];
+
+        if ($this->property) {
+            $attributes['status'] = $validated['status'];
+            $this->property->update($attributes);
+        } else {
+            auth()->user()->properties()->create($attributes);
+        }
+
+        $this->redirect(route('dashboard.properties.index'), navigate: true);
+    }
+
+    public function render()
+    {
+        return view('livewire.dashboard.property-form');
+    }
+}

--- a/app/Livewire/Public/Show.php
+++ b/app/Livewire/Public/Show.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Livewire\Public;
+
+use App\Models\Property;
+use App\Services\PropertyService;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('layouts.public')]
+class Show extends Component
+{
+    public Property $property;
+
+    public function mount($id): void
+    {
+        $this->property = app(PropertyService::class)->published()->findOrFail($id);
+    }
+
+    public function render()
+    {
+        return view('livewire.public.show');
+    }
+}

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -17,6 +17,7 @@ class Property extends Model
         return [
             'details' => 'array',
             'price' => 'decimal:2',
+            'available_from' => 'date',
         ];
     }
 

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -30,6 +30,19 @@ class Property extends Model
         return $this->hasMany(Listing::class);
     }
 
+    /**
+     * The listing that should represent this property publicly: the most
+     * recently owner-approved one that isn't archived.
+     */
+    public function activeListing(): ?Listing
+    {
+        return $this->listings
+            ->where('user_approved', true)
+            ->whereNotIn('status', ['archived'])
+            ->sortByDesc('approved_at')
+            ->first();
+    }
+
     public function media()
     {
         return $this->hasMany(PropertyMedia::class);

--- a/app/Services/PropertyService.php
+++ b/app/Services/PropertyService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\Property;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 
 class PropertyService
@@ -15,6 +16,26 @@ class PropertyService
         return Property::query()
             ->where('status', 'published')
             ->with(['listings.agency', 'media']);
+    }
+
+    /**
+     * Base query for a user's own properties, any status.
+     */
+    public function mine(User $user): Builder
+    {
+        return Property::query()
+            ->where('user_id', $user->id)
+            ->with(['listings.agency', 'media']);
+    }
+
+    /**
+     * Scope a "mine" query to the Active or Archived dashboard tab.
+     */
+    public function byTab(Builder $query, string $tab): Builder
+    {
+        return $tab === 'archived'
+            ? $query->where('status', 'archived')
+            : $query->where('status', '!=', 'archived');
     }
 
     /**

--- a/app/Services/PropertyService.php
+++ b/app/Services/PropertyService.php
@@ -19,13 +19,12 @@ class PropertyService
     }
 
     /**
-     * Base query for a user's own properties, any status.
+     * Base query for a user's own properties, any status. Callers should
+     * eager-load whichever relations their view actually needs.
      */
     public function mine(User $user): Builder
     {
-        return Property::query()
-            ->where('user_id', $user->id)
-            ->with(['listings.agency', 'media']);
+        return Property::query()->where('user_id', $user->id);
     }
 
     /**

--- a/database/migrations/2026_08_06_120925_add_available_from_to_properties_table.php
+++ b/database/migrations/2026_08_06_120925_add_available_from_to_properties_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('properties', function (Blueprint $table) {
+            $table->date('available_from')->nullable()->after('location');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('properties', function (Blueprint $table) {
+            $table->dropColumn('available_from');
+        });
+    }
+};

--- a/resources/views/components/brand-logo.blade.php
+++ b/resources/views/components/brand-logo.blade.php
@@ -1,4 +1,14 @@
+@php
+    $appName = config('app.name', 'SkyProperty - SP');
+    [$brandName, $brandTag] = str_contains($appName, ' - ')
+        ? explode(' - ', $appName, 2)
+        : [$appName, null];
+@endphp
+
 <a href="{{ route('home') }}" class="flex items-baseline gap-1.5">
-    <span class="text-lg font-bold text-green-700">SkyProperty</span>
-    <span class="rounded bg-green-700 px-1 py-0.5 text-[10px] font-bold leading-none text-white">SP</span>
+    <span class="text-lg font-bold text-green-700">{{ $brandName }}</span>
+
+    @if ($brandTag)
+        <span class="rounded bg-green-700 px-1 py-0.5 text-[10px] font-bold leading-none text-white">{{ $brandTag }}</span>
+    @endif
 </a>

--- a/resources/views/components/property-card.blade.php
+++ b/resources/views/components/property-card.blade.php
@@ -44,7 +44,7 @@
             <p class="text-sm text-gray-500">{{ $details->join(' · ') }}</p>
         @endif
 
-        @php($agency = $property->listings->first()?->agency)
+        @php($agency = $property->activeListing()?->agency)
         @if ($agency)
             <p class="text-xs text-gray-400">Listed by {{ $agency->name }}</p>
         @endif

--- a/resources/views/components/property-card.blade.php
+++ b/resources/views/components/property-card.blade.php
@@ -1,6 +1,6 @@
 @props(['property'])
 
-<article class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+<a href="{{ route('properties.show', $property->id) }}" class="block overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition hover:border-green-700 hover:shadow-md">
     <div class="aspect-video bg-gray-100">
         @php($image = $property->media->firstWhere('type', 'image'))
         @if ($image)
@@ -28,25 +28,14 @@
         @endif
 
         <p class="text-lg font-semibold text-gray-900">
-            @if ($property->price)
-                {{ $property->currency ?? 'PKR' }} {{ number_format($property->price) }}
-            @else
-                Price on request
-            @endif
+            <x-property-price :property="$property" />
         </p>
 
-        @php($details = collect([
-            isset($property->details['bedrooms']) ? $property->details['bedrooms'].' bed' : null,
-            isset($property->details['bathrooms']) ? $property->details['bathrooms'].' bath' : null,
-            isset($property->details['area_sqft']) ? $property->details['area_sqft'].' sqft' : null,
-        ])->filter())
-        @if ($details->isNotEmpty())
-            <p class="text-sm text-gray-500">{{ $details->join(' · ') }}</p>
-        @endif
+        <x-property-details-summary :property="$property" />
 
         @php($agency = $property->activeListing()?->agency)
         @if ($agency)
             <p class="text-xs text-gray-400">Listed by {{ $agency->name }}</p>
         @endif
     </div>
-</article>
+</a>

--- a/resources/views/components/property-details-summary.blade.php
+++ b/resources/views/components/property-details-summary.blade.php
@@ -1,0 +1,11 @@
+@props(['property'])
+
+@php($items = collect([
+    isset($property->details['bedrooms']) ? $property->details['bedrooms'].' bed' : null,
+    isset($property->details['bathrooms']) ? $property->details['bathrooms'].' bath' : null,
+    isset($property->details['area_sqft']) ? $property->details['area_sqft'].' sqft' : null,
+])->filter())
+
+@if ($items->isNotEmpty())
+    <p {{ $attributes->merge(['class' => 'text-sm text-gray-500']) }}>{{ $items->join(' · ') }}</p>
+@endif

--- a/resources/views/components/property-price.blade.php
+++ b/resources/views/components/property-price.blade.php
@@ -1,0 +1,9 @@
+@props(['property'])
+
+<span {{ $attributes }}>
+    @if ($property->price)
+        {{ $property->currency ?? 'PKR' }} {{ number_format($property->price) }}
+    @else
+        Price on request
+    @endif
+</span>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -16,6 +16,7 @@
 
                 <nav class="flex items-center gap-4 text-sm">
                     <a href="{{ route('dashboard') }}" class="text-gray-600 hover:text-green-700">Dashboard</a>
+                    <a href="{{ route('dashboard.properties.index') }}" class="text-gray-600 hover:text-green-700">My Properties</a>
                     <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-green-700">Browse properties</a>
 
                     <form method="POST" action="{{ route('logout') }}">

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -1,4 +1,7 @@
 <div>
     <h1 class="text-2xl font-semibold text-gray-900">Welcome, {{ auth()->user()->name }}</h1>
-    <p class="mt-2 text-gray-600">Your dashboard is coming soon.</p>
+    <p class="mt-2 text-gray-600">
+        Manage your properties from
+        <a href="{{ route('dashboard.properties.index') }}" class="font-medium text-green-700 hover:text-green-800">My Properties</a>.
+    </p>
 </div>

--- a/resources/views/livewire/dashboard/my-properties.blade.php
+++ b/resources/views/livewire/dashboard/my-properties.blade.php
@@ -1,0 +1,87 @@
+<div class="space-y-6">
+    <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold text-gray-900">My Properties</h1>
+        <a href="{{ route('dashboard.properties.create') }}" class="rounded-md bg-green-700 px-4 py-2 text-sm font-semibold text-white hover:bg-green-800">
+            Add Property
+        </a>
+    </div>
+
+    <div class="flex gap-6 border-b border-gray-200 text-sm font-medium">
+        <button
+            type="button"
+            wire:click="setTab('active')"
+            class="border-b-2 px-1 py-2 {{ $tab === 'active' ? 'border-green-700 text-green-700' : 'border-transparent text-gray-500 hover:text-gray-700' }}"
+        >
+            Active
+        </button>
+        <button
+            type="button"
+            wire:click="setTab('archived')"
+            class="border-b-2 px-1 py-2 {{ $tab === 'archived' ? 'border-green-700 text-green-700' : 'border-transparent text-gray-500 hover:text-gray-700' }}"
+        >
+            Archived
+        </button>
+    </div>
+
+    @if ($properties->isEmpty())
+        <p class="text-gray-500">
+            @if ($tab === 'archived')
+                No archived properties.
+            @else
+                You haven't added any properties yet.
+            @endif
+        </p>
+    @else
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+            <table class="w-full text-left text-sm">
+                <thead class="border-b border-gray-200 bg-gray-50 text-gray-500">
+                    <tr>
+                        <th class="px-4 py-3">Property</th>
+                        <th class="px-4 py-3">Status</th>
+                        <th class="px-4 py-3">Price</th>
+                        <th class="px-4 py-3"></th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    @foreach ($properties as $property)
+                        <tr wire:key="property-{{ $property->id }}">
+                            <td class="px-4 py-3">
+                                <div class="font-medium text-gray-900">{{ $property->title }}</div>
+                                <div class="text-gray-500">{{ $property->location }}</div>
+                            </td>
+                            <td class="px-4 py-3">
+                                <span class="rounded-full px-2 py-0.5 text-xs font-medium {{ match ($property->status) {
+                                    'published' => 'bg-green-50 text-green-700',
+                                    'archived' => 'bg-gray-100 text-gray-600',
+                                    default => 'bg-amber-50 text-amber-700',
+                                } }}">
+                                    {{ ucfirst($property->status) }}
+                                </span>
+                            </td>
+                            <td class="px-4 py-3">
+                                @if ($property->price)
+                                    {{ $property->currency ?? 'PKR' }} {{ number_format($property->price) }}
+                                @else
+                                    <span class="text-gray-400">&mdash;</span>
+                                @endif
+                            </td>
+                            <td class="px-4 py-3 text-right">
+                                <a href="{{ route('dashboard.properties.edit', $property->id) }}" class="text-green-700 hover:text-green-800">Edit</a>
+                                <button
+                                    type="button"
+                                    wire:click="delete({{ $property->id }})"
+                                    wire:confirm="Delete this property? This cannot be undone."
+                                    class="ml-3 text-red-600 hover:text-red-800"
+                                >
+                                    Delete
+                                </button>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+
+        {{ $properties->links() }}
+    @endif
+</div>

--- a/resources/views/livewire/dashboard/property-form.blade.php
+++ b/resources/views/livewire/dashboard/property-form.blade.php
@@ -1,0 +1,101 @@
+<div class="max-w-2xl space-y-6">
+    <h1 class="text-2xl font-semibold text-gray-900">{{ $property ? 'Edit Property' : 'Add Property' }}</h1>
+
+    <form wire:submit="save" class="space-y-4">
+        <div>
+            <x-input-label for="title" value="Title" />
+            <x-text-input wire:model="title" id="title" type="text" />
+            <x-input-error :messages="$errors->get('title')" class="mt-2" />
+        </div>
+
+        <div>
+            <x-input-label for="description" value="Description" />
+            <textarea
+                wire:model="description"
+                id="description"
+                rows="4"
+                class="block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm"
+            ></textarea>
+            <x-input-error :messages="$errors->get('description')" class="mt-2" />
+        </div>
+
+        <div class="grid grid-cols-2 gap-4">
+            <div>
+                <x-input-label for="type" value="Type" />
+                <select wire:model="type" id="type" class="block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm">
+                    <option value="">Select type</option>
+                    <option value="apartment">Apartment</option>
+                    <option value="house">House</option>
+                    <option value="land">Land</option>
+                    <option value="commercial">Commercial</option>
+                </select>
+                <x-input-error :messages="$errors->get('type')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="location" value="Location" />
+                <x-text-input wire:model="location" id="location" type="text" />
+                <x-input-error :messages="$errors->get('location')" class="mt-2" />
+            </div>
+        </div>
+
+        <div class="grid grid-cols-2 gap-4">
+            <div>
+                <x-input-label for="currency" value="Currency" />
+                <x-text-input wire:model="currency" id="currency" type="text" />
+                <x-input-error :messages="$errors->get('currency')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="price" value="Price" />
+                <x-text-input wire:model="price" id="price" type="number" min="0" step="0.01" />
+                <x-input-error :messages="$errors->get('price')" class="mt-2" />
+            </div>
+        </div>
+
+        <div>
+            <x-input-label for="available_from" value="Available from" />
+            <x-text-input wire:model="available_from" id="available_from" type="date" />
+            <x-input-error :messages="$errors->get('available_from')" class="mt-2" />
+        </div>
+
+        <div class="grid grid-cols-3 gap-4">
+            <div>
+                <x-input-label for="bedrooms" value="Bedrooms" />
+                <x-text-input wire:model="bedrooms" id="bedrooms" type="number" min="0" />
+                <x-input-error :messages="$errors->get('bedrooms')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="bathrooms" value="Bathrooms" />
+                <x-text-input wire:model="bathrooms" id="bathrooms" type="number" min="0" />
+                <x-input-error :messages="$errors->get('bathrooms')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="area_sqft" value="Area (sqft)" />
+                <x-text-input wire:model="area_sqft" id="area_sqft" type="number" min="0" />
+                <x-input-error :messages="$errors->get('area_sqft')" class="mt-2" />
+            </div>
+        </div>
+
+        @if ($property)
+            <div>
+                <x-input-label for="status" value="Status" />
+                <select wire:model="status" id="status" class="block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm">
+                    <option value="draft">Draft</option>
+                    <option value="published">Published</option>
+                    <option value="archived">Archived</option>
+                </select>
+                <x-input-error :messages="$errors->get('status')" class="mt-2" />
+            </div>
+        @endif
+
+        <div class="flex items-center gap-4">
+            <button type="submit" class="rounded-md bg-green-700 px-6 py-2 text-sm font-semibold text-white hover:bg-green-800">
+                {{ $property ? 'Save changes' : 'Add property' }}
+            </button>
+            <a href="{{ route('dashboard.properties.index') }}" class="text-sm text-gray-600 hover:text-green-700">Cancel</a>
+        </div>
+    </form>
+</div>

--- a/resources/views/livewire/public/show.blade.php
+++ b/resources/views/livewire/public/show.blade.php
@@ -1,0 +1,85 @@
+<div class="space-y-8">
+    <a href="{{ route('properties.index') }}" class="text-sm text-gray-600 hover:text-green-700">&larr; Back to browse</a>
+
+    @php($images = $property->media->where('type', 'image')->values())
+
+    <div x-data="{ active: 0 }" class="space-y-3">
+        <div class="aspect-video overflow-hidden rounded-lg bg-gray-100">
+            @if ($images->isNotEmpty())
+                @foreach ($images as $index => $image)
+                    <img
+                        x-show="active === {{ $index }}"
+                        src="{{ asset('storage/'.$image->path) }}"
+                        alt="{{ $property->title }}"
+                        class="h-full w-full object-cover"
+                    >
+                @endforeach
+            @else
+                <div class="flex h-full w-full items-center justify-center text-sm text-gray-400">
+                    No image
+                </div>
+            @endif
+        </div>
+
+        @if ($images->count() > 1)
+            <div class="flex gap-2 overflow-x-auto">
+                @foreach ($images as $index => $image)
+                    <button
+                        type="button"
+                        @click="active = {{ $index }}"
+                        :class="active === {{ $index }} ? 'ring-2 ring-green-700' : 'ring-1 ring-gray-200'"
+                        class="h-16 w-24 shrink-0 overflow-hidden rounded-md"
+                    >
+                        <img src="{{ asset('storage/'.$image->path) }}" alt="" class="h-full w-full object-cover">
+                    </button>
+                @endforeach
+            </div>
+        @endif
+    </div>
+
+    <div class="grid gap-8 lg:grid-cols-3">
+        <div class="space-y-4 lg:col-span-2">
+            <div class="flex items-start justify-between gap-2">
+                <h1 class="text-2xl font-semibold text-gray-900">{{ $property->title }}</h1>
+
+                @if ($property->type)
+                    <span class="shrink-0 rounded-full bg-green-50 px-3 py-1 text-sm font-medium text-green-700">
+                        {{ ucfirst($property->type) }}
+                    </span>
+                @endif
+            </div>
+
+            @if ($property->location)
+                <p class="text-gray-500">{{ $property->location }}</p>
+            @endif
+
+            <x-property-details-summary :property="$property" class="text-base text-gray-700" />
+
+            @if ($property->description)
+                <p class="whitespace-pre-line pt-4 text-gray-700">{{ $property->description }}</p>
+            @endif
+        </div>
+
+        <div class="space-y-4 rounded-lg border border-gray-200 bg-white p-6">
+            <p class="text-2xl font-semibold text-gray-900">
+                <x-property-price :property="$property" />
+            </p>
+
+            @php($agency = $property->activeListing()?->agency)
+            @if ($agency)
+                <div class="space-y-1 border-t border-gray-100 pt-4">
+                    <p class="text-sm font-medium text-gray-900">Listed by</p>
+                    <p class="text-sm text-gray-700">{{ $agency->name }}</p>
+
+                    @if ($agency->phone)
+                        <p class="text-sm text-gray-500">{{ $agency->phone }}</p>
+                    @endif
+
+                    @if ($agency->email)
+                        <p class="text-sm text-gray-500">{{ $agency->email }}</p>
+                    @endif
+                </div>
+            @endif
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,12 +1,20 @@
 <?php
 
 use App\Livewire\Dashboard;
+use App\Livewire\Dashboard\MyProperties;
+use App\Livewire\Dashboard\PropertyForm;
 use App\Livewire\Public\Browse;
 use App\Livewire\Public\Home;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', Home::class)->name('home');
 Route::get('/properties', Browse::class)->name('properties.index');
+
+Route::middleware('auth')->prefix('dashboard')->name('dashboard.')->group(function () {
+    Route::get('/properties', MyProperties::class)->name('properties.index');
+    Route::get('/properties/create', PropertyForm::class)->name('properties.create');
+    Route::get('/properties/{id}/edit', PropertyForm::class)->name('properties.edit');
+});
 
 Route::get('/dashboard', Dashboard::class)
     ->middleware('auth')

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,10 +3,12 @@
 use App\Livewire\Dashboard;
 use App\Livewire\Public\Browse;
 use App\Livewire\Public\Home;
+use App\Livewire\Public\Show;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', Home::class)->name('home');
 Route::get('/properties', Browse::class)->name('properties.index');
+Route::get('/properties/{id}', Show::class)->name('properties.show');
 
 Route::get('/dashboard', Dashboard::class)
     ->middleware('auth')

--- a/tests/Feature/Dashboard/MyPropertiesTest.php
+++ b/tests/Feature/Dashboard/MyPropertiesTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Livewire\Dashboard\MyProperties;
+use App\Models\Property;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('guests are redirected to login', function () {
+    $this->get(route('dashboard.properties.index'))->assertRedirect(route('login'));
+});
+
+test('only the authenticated user\'s own properties are listed', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+
+    Property::factory()->published()->create(['user_id' => $owner->id, 'title' => 'My Place']);
+    Property::factory()->published()->create(['user_id' => $other->id, 'title' => 'Their Place']);
+
+    Livewire::actingAs($owner)
+        ->test(MyProperties::class)
+        ->assertSee('My Place')
+        ->assertDontSee('Their Place');
+});
+
+test('active tab excludes archived properties', function () {
+    $user = User::factory()->create();
+
+    Property::factory()->draft()->create(['user_id' => $user->id, 'title' => 'Draft Place']);
+    Property::factory()->create(['user_id' => $user->id, 'status' => 'archived', 'title' => 'Archived Place']);
+
+    Livewire::actingAs($user)
+        ->test(MyProperties::class)
+        ->assertSee('Draft Place')
+        ->assertDontSee('Archived Place');
+});
+
+test('archived tab only shows archived properties', function () {
+    $user = User::factory()->create();
+
+    Property::factory()->draft()->create(['user_id' => $user->id, 'title' => 'Draft Place']);
+    Property::factory()->create(['user_id' => $user->id, 'status' => 'archived', 'title' => 'Archived Place']);
+
+    Livewire::actingAs($user)
+        ->test(MyProperties::class)
+        ->call('setTab', 'archived')
+        ->assertSee('Archived Place')
+        ->assertDontSee('Draft Place');
+});
+
+test('a user can delete their own property', function () {
+    $user = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $user->id]);
+
+    Livewire::actingAs($user)
+        ->test(MyProperties::class)
+        ->call('delete', $property->id);
+
+    expect(Property::find($property->id))->toBeNull();
+});
+
+test('a user cannot delete another user\'s property', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+
+    $this->actingAs($intruder);
+
+    expect(fn () => Livewire::test(MyProperties::class)->call('delete', $property->id))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    expect(Property::find($property->id))->not->toBeNull();
+});

--- a/tests/Feature/Dashboard/PropertyFormTest.php
+++ b/tests/Feature/Dashboard/PropertyFormTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Livewire\Dashboard\PropertyForm;
+use App\Models\Property;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('a user can create a property', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(PropertyForm::class)
+        ->set('title', 'Sunny Apartment')
+        ->set('type', 'apartment')
+        ->set('price', '5000000')
+        ->set('location', 'Lahore')
+        ->set('available_from', '2026-09-01')
+        ->set('bedrooms', '2')
+        ->call('save')
+        ->assertRedirect(route('dashboard.properties.index'));
+
+    $property = Property::where('title', 'Sunny Apartment')->first();
+
+    expect($property)->not->toBeNull();
+    expect($property->user_id)->toBe($user->id);
+    expect($property->status)->toBe('draft');
+    expect($property->available_from->format('Y-m-d'))->toBe('2026-09-01');
+    expect($property->details['bedrooms'])->toBe(2);
+});
+
+test('status cannot be set on create', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(PropertyForm::class)
+        ->set('title', 'Some Place')
+        ->set('status', 'published')
+        ->call('save');
+
+    $property = Property::where('title', 'Some Place')->first();
+
+    expect($property->status)->toBe('draft');
+});
+
+test('title is required', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(PropertyForm::class)
+        ->set('title', '')
+        ->call('save')
+        ->assertHasErrors(['title' => 'required']);
+});
+
+test('editing loads the owner\'s existing property data', function () {
+    $user = User::factory()->create();
+    $property = Property::factory()->create([
+        'user_id' => $user->id,
+        'title' => 'Existing Place',
+        'status' => 'published',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(PropertyForm::class, ['id' => $property->id])
+        ->assertSet('title', 'Existing Place')
+        ->assertSet('status', 'published');
+});
+
+test('a user cannot edit another user\'s property', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+
+    $this->actingAs($intruder);
+
+    expect(fn () => Livewire::test(PropertyForm::class, ['id' => $property->id]))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+});
+
+test('editing can change the status', function () {
+    $user = User::factory()->create();
+    $property = Property::factory()->draft()->create(['user_id' => $user->id]);
+
+    Livewire::actingAs($user)
+        ->test(PropertyForm::class, ['id' => $property->id])
+        ->set('status', 'published')
+        ->call('save');
+
+    expect($property->fresh()->status)->toBe('published');
+});

--- a/tests/Feature/PropertyActiveListingTest.php
+++ b/tests/Feature/PropertyActiveListingTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Models\Agency;
+use App\Models\Listing;
+use App\Models\Property;
+
+test('active listing ignores unapproved listings', function () {
+    $property = Property::factory()->create();
+
+    Listing::factory()->create([
+        'property_id' => $property->id,
+        'user_approved' => null,
+        'status' => 'pending',
+    ]);
+
+    expect($property->activeListing())->toBeNull();
+});
+
+test('active listing ignores archived listings even if approved', function () {
+    $property = Property::factory()->create();
+
+    Listing::factory()->create([
+        'property_id' => $property->id,
+        'user_approved' => true,
+        'status' => 'archived',
+        'approved_at' => now(),
+    ]);
+
+    expect($property->activeListing())->toBeNull();
+});
+
+test('active listing picks the most recently approved listing', function () {
+    $property = Property::factory()->create();
+    $older = Agency::factory()->create();
+    $newer = Agency::factory()->create();
+
+    Listing::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $older->id,
+        'user_approved' => true,
+        'status' => 'available',
+        'approved_at' => now()->subDay(),
+    ]);
+
+    Listing::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $newer->id,
+        'user_approved' => true,
+        'status' => 'available',
+        'approved_at' => now(),
+    ]);
+
+    expect($property->activeListing()->agency_id)->toBe($newer->id);
+});

--- a/tests/Feature/Public/ShowTest.php
+++ b/tests/Feature/Public/ShowTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Livewire\Public\Show;
+use App\Models\Property;
+use App\Models\PropertyMedia;
+use Livewire\Livewire;
+
+test('published property detail page renders its content', function () {
+    $property = Property::factory()->published()->create([
+        'title' => 'Lovely Cottage',
+        'description' => 'A lovely little cottage by the lake.',
+    ]);
+
+    Livewire::test(Show::class, ['id' => $property->id])
+        ->assertSee('Lovely Cottage')
+        ->assertSee('A lovely little cottage by the lake.');
+});
+
+test('draft property detail page 404s', function () {
+    $draft = Property::factory()->draft()->create();
+
+    $this->get("/properties/{$draft->id}")->assertNotFound();
+});
+
+test('published property detail page is reachable over http', function () {
+    $property = Property::factory()->published()->create();
+
+    $this->get("/properties/{$property->id}")->assertOk();
+});
+
+test('gallery indices stay sequential when a non-image media item sorts first', function () {
+    $property = Property::factory()->published()->create();
+
+    // A non-image item with a lower sort position would leave gaps in the
+    // media collection's keys if the image list isn't re-indexed, breaking
+    // the gallery's active-index toggle (x-show="active === N").
+    PropertyMedia::factory()->create(['property_id' => $property->id, 'type' => 'video', 'path' => 'videos/tour.mp4', 'sort_order' => 0]);
+    PropertyMedia::factory()->create(['property_id' => $property->id, 'type' => 'image', 'path' => 'images/one.jpg', 'sort_order' => 1]);
+    PropertyMedia::factory()->create(['property_id' => $property->id, 'type' => 'image', 'path' => 'images/two.jpg', 'sort_order' => 2]);
+
+    Livewire::test(Show::class, ['id' => $property->id])
+        ->assertSeeHtml('active === 0')
+        ->assertSeeHtml('active === 1')
+        ->assertDontSeeHtml('active === 2');
+});


### PR DESCRIPTION
## Summary
Syncs `develop` to `main`, bringing in #28, #31 (recreated from #29), and #30:
- Property card agency attribution fix + brand-name derived from `config('app.name')`.
- Public property detail page (`/properties/{id}`) with image gallery, description, and agency contact info.
- My Properties dashboard (`/dashboard/properties`) — list with Active/Archived tabs, create/edit form, delete, ownership enforcement. Adds `Property.available_from`.

All three already reviewed and merged into develop individually. This is a routine sync, no new changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)