### PR TITLE
Sync develop to main: My Listings dashboard

### DIFF
--- a/app/Http/Controllers/Api/ListingController.php
+++ b/app/Http/Controllers/Api/ListingController.php
@@ -10,18 +10,14 @@ use Illuminate\Http\Request;
 
 class ListingController extends Controller
 {
-    public function __construct(private ListingService $listings)
-    {
-    }
+    public function __construct(private ListingService $listings) {}
 
     /**
      * List listings on properties owned by the authenticated user.
      */
     public function index(Request $request)
     {
-        $query = Listing::whereHas('property', function ($q) use ($request) {
-            $q->where('user_id', $request->user()->id);
-        });
+        $query = $this->listings->mine($request->user());
 
         if ($request->filled('status')) {
             $query->where('status', $request->status);
@@ -86,7 +82,7 @@ class ListingController extends Controller
      */
     public function approve(Request $request, $id)
     {
-        return $this->respond($request, $id, true, 'available');
+        return $this->respond($request, $id, true);
     }
 
     /**
@@ -94,34 +90,20 @@ class ListingController extends Controller
      */
     public function reject(Request $request, $id)
     {
-        return $this->respond($request, $id, false, 'archived');
+        return $this->respond($request, $id, false);
     }
 
-    private function respond(Request $request, $id, bool $approved, string $newStatus)
+    private function respond(Request $request, $id, bool $approved)
     {
         $listing = Listing::with('property')->findOrFail($id);
 
-        if ($listing->property->user_id !== $request->user()->id) {
-            abort(403, 'You do not own the property this listing is for.');
+        try {
+            $listing = $approved
+                ? $this->listings->approve($listing, $request->user())
+                : $this->listings->reject($listing, $request->user());
+        } catch (ListingActionException $e) {
+            return response()->json(['message' => $e->getMessage()], $e->status);
         }
-
-        if (! is_null($listing->user_approved)) {
-            return response()->json(['message' => 'This listing has already been responded to.'], 409);
-        }
-
-        $fromStatus = $listing->status;
-
-        $listing->update([
-            'user_approved' => $approved,
-            'approved_at' => now(),
-            'status' => $newStatus,
-        ]);
-
-        $listing->statusHistories()->create([
-            'from_status' => $fromStatus,
-            'to_status' => $newStatus,
-            'changed_by_user_id' => $request->user()->id,
-        ]);
 
         return response()->json($listing);
     }

--- a/app/Livewire/Dashboard/MyListings.php
+++ b/app/Livewire/Dashboard/MyListings.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Livewire\Dashboard;
+
+use App\Exceptions\ListingActionException;
+use App\Services\ListingService;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+#[Layout('layouts.app')]
+class MyListings extends Component
+{
+    use WithPagination;
+
+    public ?string $error = null;
+
+    public function approve(int $listingId): void
+    {
+        $this->respond($listingId, true);
+    }
+
+    public function reject(int $listingId): void
+    {
+        $this->respond($listingId, false);
+    }
+
+    private function respond(int $listingId, bool $approved): void
+    {
+        $listings = app(ListingService::class);
+        $listing = $listings->mine(auth()->user())->findOrFail($listingId);
+
+        try {
+            $approved ? $listings->approve($listing, auth()->user()) : $listings->reject($listing, auth()->user());
+            $this->error = null;
+        } catch (ListingActionException $e) {
+            $this->error = $e->getMessage();
+        }
+    }
+
+    public function render()
+    {
+        $listings = app(ListingService::class)->mine(auth()->user())
+            ->with(['property', 'agency'])
+            ->latest()
+            ->paginate(10);
+
+        return view('livewire.dashboard.my-listings', [
+            'listings' => $listings,
+        ]);
+    }
+}

--- a/app/Livewire/Dashboard/MyListings.php
+++ b/app/Livewire/Dashboard/MyListings.php
@@ -28,7 +28,7 @@ class MyListings extends Component
     private function respond(int $listingId, bool $approved): void
     {
         $listings = app(ListingService::class);
-        $listing = $listings->mine(auth()->user())->findOrFail($listingId);
+        $listing = $listings->mine(auth()->user())->with('property')->findOrFail($listingId);
 
         try {
             $approved ? $listings->approve($listing, auth()->user()) : $listings->reject($listing, auth()->user());

--- a/app/Services/ListingService.php
+++ b/app/Services/ListingService.php
@@ -5,9 +5,64 @@ namespace App\Services;
 use App\Exceptions\ListingActionException;
 use App\Models\Agency;
 use App\Models\Listing;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
 
 class ListingService
 {
+    /**
+     * Base query for listings on properties owned by the given user.
+     */
+    public function mine(User $user): Builder
+    {
+        return Listing::whereHas('property', function ($q) use ($user) {
+            $q->where('user_id', $user->id);
+        });
+    }
+
+    /**
+     * Property owner approves a proposed listing.
+     */
+    public function approve(Listing $listing, User $user): Listing
+    {
+        return $this->respond($listing, $user, true, 'available');
+    }
+
+    /**
+     * Property owner rejects a proposed listing.
+     */
+    public function reject(Listing $listing, User $user): Listing
+    {
+        return $this->respond($listing, $user, false, 'archived');
+    }
+
+    private function respond(Listing $listing, User $user, bool $approved, string $newStatus): Listing
+    {
+        if ($listing->property->user_id !== $user->id) {
+            throw new ListingActionException('You do not own the property this listing is for.', 403);
+        }
+
+        if (! is_null($listing->user_approved)) {
+            throw new ListingActionException('This listing has already been responded to.', 409);
+        }
+
+        $fromStatus = $listing->status;
+
+        $listing->update([
+            'user_approved' => $approved,
+            'approved_at' => now(),
+            'status' => $newStatus,
+        ]);
+
+        $listing->statusHistories()->create([
+            'from_status' => $fromStatus,
+            'to_status' => $newStatus,
+            'changed_by_user_id' => $user->id,
+        ]);
+
+        return $listing;
+    }
+
     /**
      * Agency proposes a listing for a property.
      */

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -17,6 +17,7 @@
                 <nav class="flex items-center gap-4 text-sm">
                     <a href="{{ route('dashboard') }}" class="text-gray-600 hover:text-green-700">Dashboard</a>
                     <a href="{{ route('dashboard.properties.index') }}" class="text-gray-600 hover:text-green-700">My Properties</a>
+                    <a href="{{ route('dashboard.listings.index') }}" class="text-gray-600 hover:text-green-700">My Listings</a>
                     <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-green-700">Browse properties</a>
 
                     <form method="POST" action="{{ route('logout') }}">

--- a/resources/views/livewire/dashboard/my-listings.blade.php
+++ b/resources/views/livewire/dashboard/my-listings.blade.php
@@ -1,0 +1,74 @@
+<div class="space-y-6">
+    <h1 class="text-2xl font-semibold text-gray-900">My Listings</h1>
+
+    @if ($error)
+        <div class="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            {{ $error }}
+        </div>
+    @endif
+
+    @if ($listings->isEmpty())
+        <p class="text-gray-500">No agency has proposed a listing on your properties yet.</p>
+    @else
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+            <table class="w-full text-left text-sm">
+                <thead class="border-b border-gray-200 bg-gray-50 text-gray-500">
+                    <tr>
+                        <th class="px-4 py-3">Property</th>
+                        <th class="px-4 py-3">Agency</th>
+                        <th class="px-4 py-3">Status</th>
+                        <th class="px-4 py-3"></th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    @foreach ($listings as $listing)
+                        <tr wire:key="listing-{{ $listing->id }}">
+                            <td class="px-4 py-3">
+                                <div class="font-medium text-gray-900">{{ $listing->property->title }}</div>
+                                <div class="text-gray-500">{{ $listing->property->location }}</div>
+                            </td>
+                            <td class="px-4 py-3 text-gray-700">{{ $listing->agency->name }}</td>
+                            <td class="px-4 py-3">
+                                <span class="rounded-full px-2 py-0.5 text-xs font-medium {{ match ($listing->status) {
+                                    'available' => 'bg-green-50 text-green-700',
+                                    'pending' => 'bg-amber-50 text-amber-700',
+                                    'rented' => 'bg-red-50 text-red-700',
+                                    'sold' => 'bg-blue-50 text-blue-700',
+                                    default => 'bg-gray-100 text-gray-600',
+                                } }}">
+                                    {{ ucfirst($listing->status) }}
+                                </span>
+                            </td>
+                            <td class="px-4 py-3 text-right">
+                                @if (is_null($listing->user_approved))
+                                    <button
+                                        type="button"
+                                        wire:click="approve({{ $listing->id }})"
+                                        wire:confirm="Approve this agency's listing request?"
+                                        class="text-green-700 hover:text-green-800"
+                                    >
+                                        Approve
+                                    </button>
+                                    <button
+                                        type="button"
+                                        wire:click="reject({{ $listing->id }})"
+                                        wire:confirm="Reject this agency's listing request?"
+                                        class="ml-3 text-red-600 hover:text-red-800"
+                                    >
+                                        Reject
+                                    </button>
+                                @else
+                                    <span class="text-gray-400">
+                                        {{ $listing->user_approved ? 'Approved' : 'Rejected' }}
+                                    </span>
+                                @endif
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+
+        {{ $listings->links() }}
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Livewire\Dashboard;
+use App\Livewire\Dashboard\MyListings;
 use App\Livewire\Dashboard\MyProperties;
 use App\Livewire\Dashboard\PropertyForm;
 use App\Livewire\Public\Browse;
@@ -16,6 +17,7 @@ Route::middleware('auth')->prefix('dashboard')->name('dashboard.')->group(functi
     Route::get('/properties', MyProperties::class)->name('properties.index');
     Route::get('/properties/create', PropertyForm::class)->name('properties.create');
     Route::get('/properties/{id}/edit', PropertyForm::class)->name('properties.edit');
+    Route::get('/listings', MyListings::class)->name('listings.index');
 });
 
 Route::get('/dashboard', Dashboard::class)

--- a/tests/Feature/Dashboard/MyListingsTest.php
+++ b/tests/Feature/Dashboard/MyListingsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use App\Livewire\Dashboard\MyListings;
+use App\Models\Agency;
+use App\Models\Listing;
+use App\Models\Property;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('guests are redirected to login', function () {
+    $this->get(route('dashboard.listings.index'))->assertRedirect(route('login'));
+});
+
+test('only listings on the authenticated user\'s properties are shown', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+
+    $ownProperty = Property::factory()->create(['user_id' => $owner->id, 'title' => 'My House']);
+    $otherProperty = Property::factory()->create(['user_id' => $other->id, 'title' => 'Their House']);
+
+    Listing::factory()->create(['property_id' => $ownProperty->id]);
+    Listing::factory()->create(['property_id' => $otherProperty->id]);
+
+    Livewire::actingAs($owner)
+        ->test(MyListings::class)
+        ->assertSee('My House')
+        ->assertDontSee('Their House');
+});
+
+test('a pending listing shows approve and reject buttons', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    Listing::factory()->create(['property_id' => $property->id]);
+
+    Livewire::actingAs($owner)
+        ->test(MyListings::class)
+        ->assertSee('Approve')
+        ->assertSee('Reject');
+});
+
+test('owner can approve a listing', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    Livewire::actingAs($owner)
+        ->test(MyListings::class)
+        ->call('approve', $listing->id);
+
+    expect($listing->fresh()->status)->toBe('available');
+    expect($listing->fresh()->user_approved)->toBeTrue();
+});
+
+test('owner can reject a listing', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    Livewire::actingAs($owner)
+        ->test(MyListings::class)
+        ->call('reject', $listing->id);
+
+    expect($listing->fresh()->status)->toBe('archived');
+    expect($listing->fresh()->user_approved)->toBeFalse();
+});
+
+test('a user cannot respond to a listing on another user\'s property', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    $this->actingAs($intruder);
+
+    expect(fn () => Livewire::test(MyListings::class)->call('approve', $listing->id))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    expect($listing->fresh()->user_approved)->toBeNull();
+});
+
+test('responding to an already-responded listing shows an error', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    Livewire::actingAs($owner)
+        ->test(MyListings::class)
+        ->call('approve', $listing->id)
+        ->call('reject', $listing->id)
+        ->assertSet('error', 'This listing has already been responded to.');
+});
+
+test('agency name is shown for each listing', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create(['name' => 'Best Realtors']);
+    Listing::factory()->create(['property_id' => $property->id, 'agency_id' => $agency->id]);
+
+    Livewire::actingAs($owner)
+        ->test(MyListings::class)
+        ->assertSee('Best Realtors');
+});

--- a/tests/Feature/ListingApiTest.php
+++ b/tests/Feature/ListingApiTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Models\Listing;
+use App\Models\Property;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+test('owner can approve a listing via the api', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    Sanctum::actingAs($owner);
+
+    $this->postJson("/api/listings/{$listing->id}/approve")
+        ->assertOk()
+        ->assertJsonPath('status', 'available')
+        ->assertJsonPath('user_approved', true);
+});
+
+test('owner can reject a listing via the api', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    Sanctum::actingAs($owner);
+
+    $this->postJson("/api/listings/{$listing->id}/reject")
+        ->assertOk()
+        ->assertJsonPath('status', 'archived')
+        ->assertJsonPath('user_approved', false);
+});
+
+test('a non-owner cannot approve a listing via the api', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    Sanctum::actingAs($intruder);
+
+    $this->postJson("/api/listings/{$listing->id}/approve")->assertForbidden();
+});
+
+test('approving an already-responded listing conflicts', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    Sanctum::actingAs($owner);
+
+    $this->postJson("/api/listings/{$listing->id}/approve")->assertOk();
+    $this->postJson("/api/listings/{$listing->id}/reject")->assertStatus(409);
+});
+
+test('index only returns listings on the authenticated user\'s properties', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+
+    $ownProperty = Property::factory()->create(['user_id' => $owner->id]);
+    $otherProperty = Property::factory()->create(['user_id' => $other->id]);
+
+    Listing::factory()->create(['property_id' => $ownProperty->id]);
+    Listing::factory()->create(['property_id' => $otherProperty->id]);
+
+    Sanctum::actingAs($owner);
+
+    $response = $this->getJson('/api/listings');
+
+    $response->assertOk();
+    expect($response->json('data'))->toHaveCount(1);
+});

--- a/tests/Feature/ListingServiceTest.php
+++ b/tests/Feature/ListingServiceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Exceptions\ListingActionException;
+use App\Models\Listing;
+use App\Models\Property;
+use App\Models\User;
+use App\Services\ListingService;
+
+test('owner can approve a pending listing', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    $result = app(ListingService::class)->approve($listing, $owner);
+
+    expect($result->user_approved)->toBeTrue();
+    expect($result->status)->toBe('available');
+    expect($result->approved_at)->not->toBeNull();
+    expect($listing->statusHistories()->count())->toBe(1);
+});
+
+test('owner can reject a pending listing', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    $result = app(ListingService::class)->reject($listing, $owner);
+
+    expect($result->user_approved)->toBeFalse();
+    expect($result->status)->toBe('archived');
+});
+
+test('a non-owner cannot approve a listing', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    expect(fn () => app(ListingService::class)->approve($listing, $intruder))
+        ->toThrow(ListingActionException::class);
+});
+
+test('a listing that has already been responded to cannot be responded to again', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    app(ListingService::class)->approve($listing, $owner);
+
+    expect(fn () => app(ListingService::class)->reject($listing->fresh(), $owner))
+        ->toThrow(ListingActionException::class);
+});
+
+test('mine() only returns listings on the given user\'s properties', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+
+    $ownProperty = Property::factory()->create(['user_id' => $owner->id]);
+    $otherProperty = Property::factory()->create(['user_id' => $other->id]);
+
+    Listing::factory()->create(['property_id' => $ownProperty->id]);
+    Listing::factory()->create(['property_id' => $otherProperty->id]);
+
+    expect(app(ListingService::class)->mine($owner)->count())->toBe(1);
+});


### PR DESCRIPTION
## Summary
Syncs `develop` to `main`, bringing in #33:
- My Listings dashboard (`/dashboard/listings`) — approve/reject agency-proposed listings on the user's own properties.
- `ListingService::approve()`/`reject()`/`mine()` extracted from the controller, shared by the API and the new dashboard.
- Closes a pre-existing gap: the Listing API's approve/reject/index endpoints had zero test coverage before this.

Already reviewed and merged into develop in #33. This is a routine sync, no new changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)