### PR TITLE
Fix input field styling across the app

### DIFF
--- a/resources/views/components/select-input.blade.php
+++ b/resources/views/components/select-input.blade.php
@@ -1,0 +1,5 @@
+@props(['disabled' => false])
+
+<select @disabled($disabled) {{ $attributes->merge(['class' => 'block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm']) }}>
+    {{ $slot }}
+</select>

--- a/resources/views/components/text-input.blade.php
+++ b/resources/views/components/text-input.blade.php
@@ -1,3 +1,3 @@
 @props(['disabled' => false])
 
-<input @disabled($disabled) {{ $attributes->merge(['class' => 'block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm']) }}>
+<input @disabled($disabled) {{ $attributes->merge(['class' => 'block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm']) }}>

--- a/resources/views/components/textarea-input.blade.php
+++ b/resources/views/components/textarea-input.blade.php
@@ -1,0 +1,3 @@
+@props(['disabled' => false])
+
+<textarea @disabled($disabled) {{ $attributes->merge(['class' => 'block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm']) }}>{{ $slot }}</textarea>

--- a/resources/views/livewire/dashboard/property-form.blade.php
+++ b/resources/views/livewire/dashboard/property-form.blade.php
@@ -10,25 +10,20 @@
 
         <div>
             <x-input-label for="description" value="Description" />
-            <textarea
-                wire:model="description"
-                id="description"
-                rows="4"
-                class="block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm"
-            ></textarea>
+            <x-textarea-input wire:model="description" id="description" rows="4" />
             <x-input-error :messages="$errors->get('description')" class="mt-2" />
         </div>
 
         <div class="grid grid-cols-2 gap-4">
             <div>
                 <x-input-label for="type" value="Type" />
-                <select wire:model="type" id="type" class="block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm">
+                <x-select-input wire:model="type" id="type">
                     <option value="">Select type</option>
                     <option value="apartment">Apartment</option>
                     <option value="house">House</option>
                     <option value="land">Land</option>
                     <option value="commercial">Commercial</option>
-                </select>
+                </x-select-input>
                 <x-input-error :messages="$errors->get('type')" class="mt-2" />
             </div>
 
@@ -82,11 +77,11 @@
         @if ($property)
             <div>
                 <x-input-label for="status" value="Status" />
-                <select wire:model="status" id="status" class="block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm">
+                <x-select-input wire:model="status" id="status">
                     <option value="draft">Draft</option>
                     <option value="published">Published</option>
                     <option value="archived">Archived</option>
-                </select>
+                </x-select-input>
                 <x-input-error :messages="$errors->get('status')" class="mt-2" />
             </div>
         @endif

--- a/resources/views/livewire/public/browse.blade.php
+++ b/resources/views/livewire/public/browse.blade.php
@@ -9,13 +9,13 @@
 
         <div>
             <x-input-label for="type" value="Type" />
-            <select wire:model.live="type" id="type" class="block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm">
+            <x-select-input wire:model.live="type" id="type">
                 <option value="">Any type</option>
                 <option value="apartment">Apartment</option>
                 <option value="house">House</option>
                 <option value="land">Land</option>
                 <option value="commercial">Commercial</option>
-            </select>
+            </x-select-input>
         </div>
 
         <div>


### PR DESCRIPTION
## Summary
Every text/select/textarea field in the app was missing real styling. Root cause: the shared `text-input` component (and every hand-copied `<select>`/`<textarea>`) set `border-gray-300` — a border **color** utility — with no paired border **width** utility, so the actual computed `border-width` was `0px` everywhere. No padding utility was set at all either. Fields rendered as invisible-bordered, text-flush-to-the-edge boxes.

## Fix
Fixed once in shared components rather than patching each occurrence, per the ask to style all fields consistently in one place:
- `text-input.blade.php`: added `border` + `px-3 py-2`.
- New `select-input.blade.php` / `textarea-input.blade.php` components with the same treatment, replacing every raw hand-styled `<select>`/`<textarea>` in `property-form` (My Properties create/edit) and `browse` (type filter) — previously 4 separate copies of the same (broken) class string.

## Verification
Checked actual computed styles before/after, not just visual impression:
- `border`: `0px solid ...` → `1px solid ...`
- `padding`: `0px` → `8px 12px`

Verified live across Register, Login, Add/Edit Property, and Browse's filter fields — all render with consistent visible borders and padding now.

## Test plan
- [x] `php artisan test` — 58 passed (pure markup/class change, no behavior touched)
- [x] Verified live in browser on every affected page

🤖 Generated with [Claude Code](https://claude.com/claude-code)