### PR TITLE
Sync develop to main: input field styling fix

### DIFF
--- a/resources/views/components/select-input.blade.php
+++ b/resources/views/components/select-input.blade.php
@@ -1,0 +1,5 @@
+@props(['disabled' => false])
+
+<select @disabled($disabled) {{ $attributes->merge(['class' => 'block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm']) }}>
+    {{ $slot }}
+</select>

--- a/resources/views/components/text-input.blade.php
+++ b/resources/views/components/text-input.blade.php
@@ -1,3 +1,3 @@
 @props(['disabled' => false])
 
-<input @disabled($disabled) {{ $attributes->merge(['class' => 'block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm']) }}>
+<input @disabled($disabled) {{ $attributes->merge(['class' => 'block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm']) }}>

--- a/resources/views/components/textarea-input.blade.php
+++ b/resources/views/components/textarea-input.blade.php
@@ -1,0 +1,3 @@
+@props(['disabled' => false])
+
+<textarea @disabled($disabled) {{ $attributes->merge(['class' => 'block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm']) }}>{{ $slot }}</textarea>

--- a/resources/views/livewire/dashboard/property-form.blade.php
+++ b/resources/views/livewire/dashboard/property-form.blade.php
@@ -10,25 +10,20 @@
 
         <div>
             <x-input-label for="description" value="Description" />
-            <textarea
-                wire:model="description"
-                id="description"
-                rows="4"
-                class="block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm"
-            ></textarea>
+            <x-textarea-input wire:model="description" id="description" rows="4" />
             <x-input-error :messages="$errors->get('description')" class="mt-2" />
         </div>
 
         <div class="grid grid-cols-2 gap-4">
             <div>
                 <x-input-label for="type" value="Type" />
-                <select wire:model="type" id="type" class="block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm">
+                <x-select-input wire:model="type" id="type">
                     <option value="">Select type</option>
                     <option value="apartment">Apartment</option>
                     <option value="house">House</option>
                     <option value="land">Land</option>
                     <option value="commercial">Commercial</option>
-                </select>
+                </x-select-input>
                 <x-input-error :messages="$errors->get('type')" class="mt-2" />
             </div>
 
@@ -82,11 +77,11 @@
         @if ($property)
             <div>
                 <x-input-label for="status" value="Status" />
-                <select wire:model="status" id="status" class="block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm">
+                <x-select-input wire:model="status" id="status">
                     <option value="draft">Draft</option>
                     <option value="published">Published</option>
                     <option value="archived">Archived</option>
-                </select>
+                </x-select-input>
                 <x-input-error :messages="$errors->get('status')" class="mt-2" />
             </div>
         @endif

--- a/resources/views/livewire/public/browse.blade.php
+++ b/resources/views/livewire/public/browse.blade.php
@@ -9,13 +9,13 @@
 
         <div>
             <x-input-label for="type" value="Type" />
-            <select wire:model.live="type" id="type" class="block w-full rounded-md border-gray-300 shadow-sm outline-none focus:border-green-700 focus:ring-2 focus:ring-green-700 sm:text-sm">
+            <x-select-input wire:model.live="type" id="type">
                 <option value="">Any type</option>
                 <option value="apartment">Apartment</option>
                 <option value="house">House</option>
                 <option value="land">Land</option>
                 <option value="commercial">Commercial</option>
-            </select>
+            </x-select-input>
         </div>
 
         <div>


### PR DESCRIPTION
## Summary
Syncs `develop` to `main`, bringing in #35:
- Fixes every text/select/textarea field across the app, which was missing real border/padding styling (border-color was set without a paired border-width utility, so borders computed to 0px everywhere). Fixed once in shared components (`text-input`, plus new `select-input`/`textarea-input`) rather than patching each page.

Already reviewed and merged into develop in #35. This is a routine sync, no new changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)