### PR TITLE
Add My Connections dashboard

### DIFF
--- a/app/Exceptions/ConnectionActionException.php
+++ b/app/Exceptions/ConnectionActionException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class ConnectionActionException extends Exception
+{
+    public function __construct(string $message, public readonly int $status = 409)
+    {
+        parent::__construct($message);
+    }
+}

--- a/app/Http/Controllers/Api/ConnectionController.php
+++ b/app/Http/Controllers/Api/ConnectionController.php
@@ -2,12 +2,16 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Exceptions\ConnectionActionException;
 use App\Http\Controllers\Controller;
 use App\Models\Connection;
+use App\Services\ConnectionService;
 use Illuminate\Http\Request;
 
 class ConnectionController extends Controller
 {
+    public function __construct(private ConnectionService $connections) {}
+
     /**
      * Agency lists the connections it has initiated.
      */
@@ -58,9 +62,7 @@ class ConnectionController extends Controller
      */
     public function index(Request $request)
     {
-        $query = Connection::whereHas('property', function ($q) use ($request) {
-            $q->where('user_id', $request->user()->id);
-        });
+        $query = $this->connections->mine($request->user());
 
         if ($request->filled('status')) {
             $query->where('status', $request->status);
@@ -73,33 +75,25 @@ class ConnectionController extends Controller
 
     public function accept(Request $request, $id)
     {
-        return $this->respond($request, $id, 'accepted');
+        return $this->respond($request, $id, true);
     }
 
     public function reject(Request $request, $id)
     {
-        return $this->respond($request, $id, 'rejected');
+        return $this->respond($request, $id, false);
     }
 
-    private function respond(Request $request, $id, string $newStatus)
+    private function respond(Request $request, $id, bool $accepted)
     {
         $connection = Connection::with('property')->findOrFail($id);
 
-        if (! $connection->property || $connection->property->user_id !== $request->user()->id) {
-            abort(403, 'You do not own the property this connection is for.');
+        try {
+            $connection = $accepted
+                ? $this->connections->accept($connection, $request->user())
+                : $this->connections->reject($connection, $request->user());
+        } catch (ConnectionActionException $e) {
+            return response()->json(['message' => $e->getMessage()], $e->status);
         }
-
-        if ($connection->expires_at && $connection->expires_at->isPast() && $connection->status === 'pending') {
-            $connection->update(['status' => 'expired']);
-        }
-
-        if ($connection->status !== 'pending') {
-            return response()->json([
-                'message' => "This connection request is no longer pending (status: {$connection->status}).",
-            ], 409);
-        }
-
-        $connection->update(['status' => $newStatus]);
 
         return response()->json($connection);
     }

--- a/app/Livewire/Dashboard/MyConnections.php
+++ b/app/Livewire/Dashboard/MyConnections.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Livewire\Dashboard;
+
+use App\Exceptions\ConnectionActionException;
+use App\Services\ConnectionService;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+#[Layout('layouts.app')]
+class MyConnections extends Component
+{
+    use WithPagination;
+
+    public ?string $error = null;
+
+    public function accept(int $connectionId): void
+    {
+        $this->respond($connectionId, true);
+    }
+
+    public function reject(int $connectionId): void
+    {
+        $this->respond($connectionId, false);
+    }
+
+    private function respond(int $connectionId, bool $accepted): void
+    {
+        $connections = app(ConnectionService::class);
+        $connection = $connections->mine(auth()->user())->with('property')->findOrFail($connectionId);
+
+        try {
+            $accepted ? $connections->accept($connection, auth()->user()) : $connections->reject($connection, auth()->user());
+            $this->error = null;
+        } catch (ConnectionActionException $e) {
+            $this->error = $e->getMessage();
+        }
+    }
+
+    public function render()
+    {
+        $connections = app(ConnectionService::class)->mine(auth()->user())
+            ->with(['property', 'agency'])
+            ->latest()
+            ->paginate(10);
+
+        return view('livewire.dashboard.my-connections', [
+            'connections' => $connections,
+        ]);
+    }
+}

--- a/app/Services/ConnectionService.php
+++ b/app/Services/ConnectionService.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Services;
+
+use App\Exceptions\ConnectionActionException;
+use App\Models\Connection;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+
+class ConnectionService
+{
+    /**
+     * Base query for connections aimed at properties owned by the given user.
+     */
+    public function mine(User $user): Builder
+    {
+        return Connection::whereHas('property', function ($q) use ($user) {
+            $q->where('user_id', $user->id);
+        });
+    }
+
+    /**
+     * Property owner accepts a pending connection request.
+     */
+    public function accept(Connection $connection, User $user): Connection
+    {
+        return $this->respond($connection, $user, 'accepted');
+    }
+
+    /**
+     * Property owner rejects a pending connection request.
+     */
+    public function reject(Connection $connection, User $user): Connection
+    {
+        return $this->respond($connection, $user, 'rejected');
+    }
+
+    private function respond(Connection $connection, User $user, string $newStatus): Connection
+    {
+        if (! $connection->property || $connection->property->user_id !== $user->id) {
+            throw new ConnectionActionException('You do not own the property this connection is for.', 403);
+        }
+
+        if ($connection->expires_at && $connection->expires_at->isPast() && $connection->status === 'pending') {
+            $connection->update(['status' => 'expired']);
+        }
+
+        if ($connection->status !== 'pending') {
+            throw new ConnectionActionException(
+                "This connection request is no longer pending (status: {$connection->status}).",
+                409
+            );
+        }
+
+        $connection->update(['status' => $newStatus]);
+
+        return $connection;
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -18,6 +18,7 @@
                     <a href="{{ route('dashboard') }}" class="text-gray-600 hover:text-green-700">Dashboard</a>
                     <a href="{{ route('dashboard.properties.index') }}" class="text-gray-600 hover:text-green-700">My Properties</a>
                     <a href="{{ route('dashboard.listings.index') }}" class="text-gray-600 hover:text-green-700">My Listings</a>
+                    <a href="{{ route('dashboard.connections.index') }}" class="text-gray-600 hover:text-green-700">My Connections</a>
                     <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-green-700">Browse properties</a>
 
                     <form method="POST" action="{{ route('logout') }}">

--- a/resources/views/livewire/dashboard/my-connections.blade.php
+++ b/resources/views/livewire/dashboard/my-connections.blade.php
@@ -1,0 +1,63 @@
+<div class="space-y-6">
+    <h1 class="text-2xl font-semibold text-gray-900">My Connections</h1>
+
+    @if ($error)
+        <div class="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            {{ $error }}
+        </div>
+    @endif
+
+    @if ($connections->isEmpty())
+        <p class="text-gray-500">No agency has reached out about your properties yet.</p>
+    @else
+        <div class="space-y-4">
+            @foreach ($connections as $connection)
+                <div wire:key="connection-{{ $connection->id }}" class="rounded-lg border border-gray-200 bg-white p-4">
+                    <div class="flex items-start justify-between gap-4">
+                        <div>
+                            <div class="font-medium text-gray-900">{{ $connection->property->title }}</div>
+                            <div class="text-sm text-gray-500">{{ $connection->property->location }}</div>
+                            <div class="mt-1 text-sm text-gray-700">From {{ $connection->agency->name }}</div>
+                        </div>
+
+                        <span class="shrink-0 rounded-full px-2 py-0.5 text-xs font-medium {{ match ($connection->status) {
+                            'accepted' => 'bg-green-50 text-green-700',
+                            'pending' => 'bg-amber-50 text-amber-700',
+                            'rejected' => 'bg-red-50 text-red-700',
+                            default => 'bg-gray-100 text-gray-600',
+                        } }}">
+                            {{ ucfirst($connection->status) }}
+                        </span>
+                    </div>
+
+                    @if ($connection->message)
+                        <p class="mt-3 text-sm text-gray-600">&ldquo;{{ $connection->message }}&rdquo;</p>
+                    @endif
+
+                    @if ($connection->status === 'pending')
+                        <div class="mt-4">
+                            <button
+                                type="button"
+                                wire:click="accept({{ $connection->id }})"
+                                wire:confirm="Accept this agency's connection request?"
+                                class="text-green-700 hover:text-green-800"
+                            >
+                                Accept
+                            </button>
+                            <button
+                                type="button"
+                                wire:click="reject({{ $connection->id }})"
+                                wire:confirm="Reject this agency's connection request?"
+                                class="ml-3 text-red-600 hover:text-red-800"
+                            >
+                                Reject
+                            </button>
+                        </div>
+                    @endif
+                </div>
+            @endforeach
+        </div>
+
+        {{ $connections->links() }}
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Livewire\Dashboard;
+use App\Livewire\Dashboard\MyConnections;
 use App\Livewire\Dashboard\MyListings;
 use App\Livewire\Dashboard\MyProperties;
 use App\Livewire\Dashboard\PropertyForm;
@@ -18,6 +19,7 @@ Route::middleware('auth')->prefix('dashboard')->name('dashboard.')->group(functi
     Route::get('/properties/create', PropertyForm::class)->name('properties.create');
     Route::get('/properties/{id}/edit', PropertyForm::class)->name('properties.edit');
     Route::get('/listings', MyListings::class)->name('listings.index');
+    Route::get('/connections', MyConnections::class)->name('connections.index');
 });
 
 Route::get('/dashboard', Dashboard::class)

--- a/tests/Feature/ConnectionApiTest.php
+++ b/tests/Feature/ConnectionApiTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Models\Connection;
+use App\Models\Property;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+test('owner can accept a connection via the api', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create(['property_id' => $property->id]);
+
+    Sanctum::actingAs($owner);
+
+    $this->postJson("/api/connections/{$connection->id}/accept")
+        ->assertOk()
+        ->assertJsonPath('status', 'accepted');
+});
+
+test('owner can reject a connection via the api', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create(['property_id' => $property->id]);
+
+    Sanctum::actingAs($owner);
+
+    $this->postJson("/api/connections/{$connection->id}/reject")
+        ->assertOk()
+        ->assertJsonPath('status', 'rejected');
+});
+
+test('a non-owner cannot accept a connection via the api', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create(['property_id' => $property->id]);
+
+    Sanctum::actingAs($intruder);
+
+    $this->postJson("/api/connections/{$connection->id}/accept")->assertForbidden();
+});
+
+test('accepting an already-responded connection conflicts', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create(['property_id' => $property->id]);
+
+    Sanctum::actingAs($owner);
+
+    $this->postJson("/api/connections/{$connection->id}/accept")->assertOk();
+    $this->postJson("/api/connections/{$connection->id}/reject")->assertStatus(409);
+});
+
+test('a past-expiry connection cannot be accepted and is marked expired', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create([
+        'property_id' => $property->id,
+        'expires_at' => now()->subHour(),
+    ]);
+
+    Sanctum::actingAs($owner);
+
+    $this->postJson("/api/connections/{$connection->id}/accept")->assertStatus(409);
+
+    expect($connection->fresh()->status)->toBe('expired');
+});
+
+test('index only returns connections on the authenticated user\'s properties', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+
+    $ownProperty = Property::factory()->create(['user_id' => $owner->id]);
+    $otherProperty = Property::factory()->create(['user_id' => $other->id]);
+
+    Connection::factory()->create(['property_id' => $ownProperty->id]);
+    Connection::factory()->create(['property_id' => $otherProperty->id]);
+
+    Sanctum::actingAs($owner);
+
+    $response = $this->getJson('/api/connections');
+
+    $response->assertOk();
+    expect($response->json('data'))->toHaveCount(1);
+});

--- a/tests/Feature/ConnectionServiceTest.php
+++ b/tests/Feature/ConnectionServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use App\Exceptions\ConnectionActionException;
+use App\Models\Connection;
+use App\Models\Property;
+use App\Models\User;
+use App\Services\ConnectionService;
+
+test('owner can accept a pending connection', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create(['property_id' => $property->id]);
+
+    $result = app(ConnectionService::class)->accept($connection, $owner);
+
+    expect($result->status)->toBe('accepted');
+});
+
+test('owner can reject a pending connection', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create(['property_id' => $property->id]);
+
+    $result = app(ConnectionService::class)->reject($connection, $owner);
+
+    expect($result->status)->toBe('rejected');
+});
+
+test('a non-owner cannot accept a connection', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create(['property_id' => $property->id]);
+
+    expect(fn () => app(ConnectionService::class)->accept($connection, $intruder))
+        ->toThrow(ConnectionActionException::class);
+});
+
+test('a connection that has already been responded to cannot be responded to again', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create(['property_id' => $property->id]);
+
+    app(ConnectionService::class)->accept($connection, $owner);
+
+    expect(fn () => app(ConnectionService::class)->reject($connection->fresh(), $owner))
+        ->toThrow(ConnectionActionException::class);
+});
+
+test('a pending connection past its expiry is transitioned to expired instead of responded to', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create([
+        'property_id' => $property->id,
+        'expires_at' => now()->subDay(),
+    ]);
+
+    expect(fn () => app(ConnectionService::class)->accept($connection, $owner))
+        ->toThrow(ConnectionActionException::class);
+
+    expect($connection->fresh()->status)->toBe('expired');
+});
+
+test('a connection with a future expiry can still be accepted', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create([
+        'property_id' => $property->id,
+        'expires_at' => now()->addDay(),
+    ]);
+
+    $result = app(ConnectionService::class)->accept($connection, $owner);
+
+    expect($result->status)->toBe('accepted');
+});
+
+test('mine() only returns connections on the given user\'s properties', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+
+    $ownProperty = Property::factory()->create(['user_id' => $owner->id]);
+    $otherProperty = Property::factory()->create(['user_id' => $other->id]);
+
+    Connection::factory()->create(['property_id' => $ownProperty->id]);
+    Connection::factory()->create(['property_id' => $otherProperty->id]);
+
+    expect(app(ConnectionService::class)->mine($owner)->count())->toBe(1);
+});

--- a/tests/Feature/Dashboard/MyConnectionsTest.php
+++ b/tests/Feature/Dashboard/MyConnectionsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use App\Livewire\Dashboard\MyConnections;
+use App\Models\Agency;
+use App\Models\Connection;
+use App\Models\Property;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('guests are redirected to login', function () {
+    $this->get(route('dashboard.connections.index'))->assertRedirect(route('login'));
+});
+
+test('only connections on the authenticated user\'s properties are shown', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+
+    $ownProperty = Property::factory()->create(['user_id' => $owner->id, 'title' => 'My House']);
+    $otherProperty = Property::factory()->create(['user_id' => $other->id, 'title' => 'Their House']);
+
+    Connection::factory()->create(['property_id' => $ownProperty->id]);
+    Connection::factory()->create(['property_id' => $otherProperty->id]);
+
+    Livewire::actingAs($owner)
+        ->test(MyConnections::class)
+        ->assertSee('My House')
+        ->assertDontSee('Their House');
+});
+
+test('a pending connection shows accept and reject buttons', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    Connection::factory()->create(['property_id' => $property->id]);
+
+    Livewire::actingAs($owner)
+        ->test(MyConnections::class)
+        ->assertSee('Accept')
+        ->assertSee('Reject');
+});
+
+test('owner can accept a connection', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create(['property_id' => $property->id]);
+
+    Livewire::actingAs($owner)
+        ->test(MyConnections::class)
+        ->call('accept', $connection->id);
+
+    expect($connection->fresh()->status)->toBe('accepted');
+});
+
+test('owner can reject a connection', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create(['property_id' => $property->id]);
+
+    Livewire::actingAs($owner)
+        ->test(MyConnections::class)
+        ->call('reject', $connection->id);
+
+    expect($connection->fresh()->status)->toBe('rejected');
+});
+
+test('a user cannot respond to a connection on another user\'s property', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create(['property_id' => $property->id]);
+
+    $this->actingAs($intruder);
+
+    expect(fn () => Livewire::test(MyConnections::class)->call('accept', $connection->id))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    expect($connection->fresh()->status)->toBe('pending');
+});
+
+test('responding to an already-responded connection shows an error', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create(['property_id' => $property->id]);
+
+    Livewire::actingAs($owner)
+        ->test(MyConnections::class)
+        ->call('accept', $connection->id)
+        ->call('reject', $connection->id)
+        ->assertSet('error', 'This connection request is no longer pending (status: accepted).');
+});
+
+test('agency name and message are shown for each connection', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create(['name' => 'Best Realtors']);
+    Connection::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'message' => 'We would love to list this property.',
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(MyConnections::class)
+        ->assertSee('Best Realtors')
+        ->assertSee('We would love to list this property.');
+});


### PR DESCRIPTION
## Summary
- Extracts the property owner's accept/reject logic out of `ConnectionController::respond()` into `ConnectionService::accept()`/`reject()`/`mine()`, matching the `PropertyService`/`ListingService` pattern from earlier PRs.
- Preserves the exact expiry-then-conflict check order: a pending connection past its `expires_at` gets transitioned to `expired` *before* the pending-check runs, so it correctly returns a 409 conflict rather than silently accepting a stale request. This is real, non-trivial business logic that had to survive the refactor intact.
- New `/dashboard/connections` page: connections aimed at the user's properties (property, agency, message), with Accept/Reject for pending ones.

## Applying last review's lesson up front
The #33 review flagged that `MyListings::respond()` fetched a listing via `mine()` without eager-loading `property`, causing a lazy-load per click. Applied that lesson from the start here — `MyConnections::respond()` eager-loads `property` at the call site rather than baking it into the shared `mine()` query.

## Gap closed
The Connection API's `accept`/`reject`/`index` endpoints — including the expiry-transition behavior — had zero test coverage before this, despite being live. Added `ConnectionApiTest` alongside the service/dashboard tests.

## Test plan
- [x] `php artisan test` — 79 passed (21 new: service-level accept/reject/authorization/conflict/expiry-transition, API-level regression, dashboard scoping/actions/error-state)
- [x] `./vendor/bin/pint --test` clean on all changed files
- [x] Verified live: seeded a real owner + property + agency + pending connection with a message, confirmed the dashboard shows it correctly scoped with Accept/Reject, accepted it via the API (native `wire:confirm` dialog can't be driven by this environment's browser automation), confirmed the dashboard immediately reflects "Accepted" with no further action available

🤖 Generated with [Claude Code](https://claude.com/claude-code)