### PR TITLE
Profile settings, complete-profile nudge, delete account, logout confirmation

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidationException;
 
 class AuthController extends Controller
@@ -60,6 +61,61 @@ class AuthController extends Controller
     public function profile(Request $request)
     {
         return response()->json($request->user());
+    }
+
+    /**
+     * Update the authenticated user's own profile.
+     */
+    public function updateProfile(Request $request)
+    {
+        $user = $request->user();
+
+        $validated = $request->validate([
+            'name' => 'sometimes|required|string|max:255',
+            'email' => 'sometimes|required|email|max:255|unique:users,email,'.$user->id,
+            'phone' => 'sometimes|required|string|max:255|unique:users,phone,'.$user->id,
+            'password' => 'sometimes|required|string|min:6|confirmed',
+            'avatar' => 'sometimes|nullable|image|max:2048',
+        ]);
+
+        if (isset($validated['password'])) {
+            $validated['password'] = Hash::make($validated['password']);
+        }
+
+        if ($request->hasFile('avatar')) {
+            if ($user->avatar) {
+                Storage::disk('public')->delete($user->avatar);
+            }
+
+            $validated['avatar'] = $request->file('avatar')->store('avatars', 'public');
+        }
+
+        $user->update($validated);
+
+        return response()->json($user->fresh());
+    }
+
+    /**
+     * Delete (soft-delete) the authenticated user's own account.
+     */
+    public function destroyAccount(Request $request)
+    {
+        $request->validate([
+            'password' => 'required|string',
+        ]);
+
+        $user = $request->user();
+
+        if (! Hash::check($request->password, $user->password)) {
+            throw ValidationException::withMessages([
+                'password' => ['The provided password is incorrect.'],
+            ]);
+        }
+
+        $user->tokens()->delete();
+        $user->delete();
+
+        return response()->json(['message' => 'Account deleted successfully']);
     }
 
     public function logout(Request $request)

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -74,13 +74,22 @@ class AuthController extends Controller
             'name' => 'sometimes|required|string|max:255',
             'email' => 'sometimes|required|email|max:255|unique:users,email,'.$user->id,
             'phone' => 'sometimes|required|string|max:255|unique:users,phone,'.$user->id,
+            'current_password' => 'required_with:password|string',
             'password' => 'sometimes|required|string|min:6|confirmed',
             'avatar' => 'sometimes|nullable|image|max:2048',
         ]);
 
         if (isset($validated['password'])) {
+            if (! Hash::check($validated['current_password'], $user->password)) {
+                throw ValidationException::withMessages([
+                    'current_password' => ['The provided password is incorrect.'],
+                ]);
+            }
+
             $validated['password'] = Hash::make($validated['password']);
         }
+
+        unset($validated['current_password']);
 
         if ($request->hasFile('avatar')) {
             if ($user->avatar) {

--- a/app/Livewire/Dashboard/ProfileSettings.php
+++ b/app/Livewire/Dashboard/ProfileSettings.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Livewire\Dashboard;
+
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Rule;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+
+#[Layout('layouts.app')]
+class ProfileSettings extends Component
+{
+    use WithFileUploads;
+
+    public string $name = '';
+
+    public string $email = '';
+
+    public string $phone = '';
+
+    public $avatar = null;
+
+    public ?string $statusMessage = null;
+
+    public string $current_password = '';
+
+    public string $password = '';
+
+    public string $password_confirmation = '';
+
+    public ?string $passwordStatusMessage = null;
+
+    public string $delete_password = '';
+
+    public function mount(): void
+    {
+        $user = auth()->user();
+
+        $this->name = $user->name;
+        $this->email = $user->email;
+        $this->phone = $user->phone;
+    }
+
+    public function updateProfile(): void
+    {
+        $user = auth()->user();
+
+        $validated = $this->validate([
+            'name' => 'required|string|max:255',
+            'email' => ['required', 'email', 'max:255', Rule::unique('users', 'email')->ignore($user->id)],
+            'phone' => ['required', 'string', 'max:255', Rule::unique('users', 'phone')->ignore($user->id)],
+            'avatar' => 'nullable|image|max:2048',
+        ]);
+
+        if ($this->avatar) {
+            if ($user->avatar) {
+                Storage::disk('public')->delete($user->avatar);
+            }
+
+            $validated['avatar'] = $this->avatar->store('avatars', 'public');
+        } else {
+            unset($validated['avatar']);
+        }
+
+        $user->update($validated);
+
+        $this->avatar = null;
+        $this->statusMessage = 'Profile updated.';
+    }
+
+    public function updatePassword(): void
+    {
+        $user = auth()->user();
+
+        $validated = $this->validate([
+            'current_password' => 'required|string',
+            'password' => 'required|string|min:6|confirmed',
+        ]);
+
+        if (! Hash::check($validated['current_password'], $user->password)) {
+            $this->addError('current_password', 'The current password is incorrect.');
+
+            return;
+        }
+
+        $user->update(['password' => Hash::make($validated['password'])]);
+
+        $this->current_password = '';
+        $this->password = '';
+        $this->password_confirmation = '';
+        $this->passwordStatusMessage = 'Password updated.';
+    }
+
+    public function deleteAccount(): void
+    {
+        $user = auth()->user();
+
+        $this->validate(['delete_password' => 'required|string']);
+
+        if (! Hash::check($this->delete_password, $user->password)) {
+            $this->addError('delete_password', 'The password is incorrect.');
+
+            return;
+        }
+
+        $user->delete();
+
+        auth()->guard('web')->logout();
+        session()->invalidate();
+        session()->regenerateToken();
+
+        $this->redirect(route('home'), navigate: true);
+    }
+
+    public function render()
+    {
+        return view('livewire.dashboard.profile-settings');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,7 +23,9 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
-        'phone'
+        'phone',
+        'avatar',
+        'meta',
     ];
 
     /**
@@ -46,6 +48,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'meta' => 'array',
         ];
     }
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -20,8 +20,9 @@
                     <a href="{{ route('dashboard.listings.index') }}" class="text-gray-600 hover:text-green-700">My Listings</a>
                     <a href="{{ route('dashboard.connections.index') }}" class="text-gray-600 hover:text-green-700">My Connections</a>
                     <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-green-700">Browse properties</a>
+                    <a href="{{ route('dashboard.settings') }}" class="text-gray-600 hover:text-green-700">Settings</a>
 
-                    <form method="POST" action="{{ route('logout') }}">
+                    <form method="POST" action="{{ route('logout') }}" onsubmit="return confirm('Are you sure you want to log out?');">
                         @csrf
                         <button type="submit" class="text-gray-600 hover:text-green-700">Log out</button>
                     </form>

--- a/resources/views/layouts/public.blade.php
+++ b/resources/views/layouts/public.blade.php
@@ -20,7 +20,7 @@
                     @auth
                         <a href="{{ route('dashboard') }}" class="text-gray-600 hover:text-green-700">Dashboard</a>
 
-                        <form method="POST" action="{{ route('logout') }}">
+                        <form method="POST" action="{{ route('logout') }}" onsubmit="return confirm('Are you sure you want to log out?');">
                             @csrf
                             <button type="submit" class="text-gray-600 hover:text-green-700">Log out</button>
                         </form>

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -4,4 +4,16 @@
         Manage your properties from
         <a href="{{ route('dashboard.properties.index') }}" class="font-medium text-green-700 hover:text-green-800">My Properties</a>.
     </p>
+
+    @unless (auth()->user()->avatar)
+        <div class="mt-6 flex items-center justify-between rounded-lg border border-green-200 bg-green-50 p-4">
+            <div>
+                <p class="font-medium text-green-900">Complete your profile</p>
+                <p class="text-sm text-green-700">Add a profile photo so agencies and owners recognize you.</p>
+            </div>
+            <a href="{{ route('dashboard.settings') }}" class="rounded-md bg-green-700 px-4 py-2 text-sm font-semibold text-white hover:bg-green-800">
+                Complete profile
+            </a>
+        </div>
+    @endunless
 </div>

--- a/resources/views/livewire/dashboard/profile-settings.blade.php
+++ b/resources/views/livewire/dashboard/profile-settings.blade.php
@@ -1,0 +1,108 @@
+<div class="max-w-2xl space-y-10">
+    <h1 class="text-2xl font-semibold text-gray-900">Profile & Settings</h1>
+
+    <section class="space-y-4 rounded-lg border border-gray-200 bg-white p-6">
+        <h2 class="text-lg font-semibold text-gray-900">Profile</h2>
+
+        @if ($statusMessage)
+            <div class="rounded-md bg-green-50 p-3 text-sm text-green-700">{{ $statusMessage }}</div>
+        @endif
+
+        <form wire:submit="updateProfile" class="space-y-4">
+            <div class="flex items-center gap-4">
+                <div class="h-16 w-16 shrink-0 overflow-hidden rounded-full bg-gray-100">
+                    @if ($avatar)
+                        <img src="{{ $avatar->temporaryUrl() }}" alt="Avatar preview" class="h-full w-full object-cover">
+                    @elseif (auth()->user()->avatar)
+                        <img src="{{ asset('storage/'.auth()->user()->avatar) }}" alt="Avatar" class="h-full w-full object-cover">
+                    @else
+                        <div class="flex h-full w-full items-center justify-center text-xs text-gray-400">No photo</div>
+                    @endif
+                </div>
+
+                <div>
+                    <label class="inline-block cursor-pointer rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                        Change photo
+                        <input wire:model="avatar" type="file" accept="image/*" class="hidden">
+                    </label>
+                    <div wire:loading wire:target="avatar" class="mt-1 text-xs text-gray-500">Uploading&hellip;</div>
+                    <x-input-error :messages="$errors->get('avatar')" class="mt-1" />
+                </div>
+            </div>
+
+            <div>
+                <x-input-label for="name" value="Name" />
+                <x-text-input wire:model="name" id="name" type="text" />
+                <x-input-error :messages="$errors->get('name')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="email" value="Email" />
+                <x-text-input wire:model="email" id="email" type="email" />
+                <x-input-error :messages="$errors->get('email')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="phone" value="Phone" />
+                <x-text-input wire:model="phone" id="phone" type="text" />
+                <x-input-error :messages="$errors->get('phone')" class="mt-2" />
+            </div>
+
+            <button type="submit" class="rounded-md bg-green-700 px-6 py-2 text-sm font-semibold text-white hover:bg-green-800">
+                Save changes
+            </button>
+        </form>
+    </section>
+
+    <section class="space-y-4 rounded-lg border border-gray-200 bg-white p-6">
+        <h2 class="text-lg font-semibold text-gray-900">Change password</h2>
+
+        @if ($passwordStatusMessage)
+            <div class="rounded-md bg-green-50 p-3 text-sm text-green-700">{{ $passwordStatusMessage }}</div>
+        @endif
+
+        <form wire:submit="updatePassword" class="space-y-4">
+            <div>
+                <x-input-label for="current_password" value="Current password" />
+                <x-text-input wire:model="current_password" id="current_password" type="password" autocomplete="current-password" />
+                <x-input-error :messages="$errors->get('current_password')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="password" value="New password" />
+                <x-text-input wire:model="password" id="password" type="password" autocomplete="new-password" />
+                <x-input-error :messages="$errors->get('password')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="password_confirmation" value="Confirm new password" />
+                <x-text-input wire:model="password_confirmation" id="password_confirmation" type="password" autocomplete="new-password" />
+                <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2" />
+            </div>
+
+            <button type="submit" class="rounded-md bg-green-700 px-6 py-2 text-sm font-semibold text-white hover:bg-green-800">
+                Update password
+            </button>
+        </form>
+    </section>
+
+    <section class="space-y-4 rounded-lg border border-red-200 bg-white p-6">
+        <h2 class="text-lg font-semibold text-red-700">Danger zone</h2>
+        <p class="text-sm text-gray-600">
+            Deleting your account is permanent. All of your properties, listings, and connections will remain associated
+            with your account record but you will no longer be able to log in.
+        </p>
+
+        <form wire:submit="deleteAccount" wire:confirm="Are you absolutely sure you want to delete your account? This cannot be undone." class="space-y-4">
+            <div class="max-w-sm">
+                <x-input-label for="delete_password" value="Confirm your password" />
+                <x-text-input wire:model="delete_password" id="delete_password" type="password" />
+                <x-input-error :messages="$errors->get('delete_password')" class="mt-2" />
+            </div>
+
+            <button type="submit" class="rounded-md bg-red-600 px-6 py-2 text-sm font-semibold text-white hover:bg-red-700">
+                Delete my account
+            </button>
+        </form>
+    </section>
+</div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,8 @@ Route::prefix('properties')->group(function () {
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('/profile', [AuthController::class, 'profile']);
+    Route::put('/profile', [AuthController::class, 'updateProfile']);
+    Route::delete('/profile', [AuthController::class, 'destroyAccount']);
     Route::post('/logout', [AuthController::class, 'logout']);
 
     Route::get('/my-properties', [PropertyController::class, 'mine']); // my own, any status

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Livewire\Dashboard\MyConnections;
 use App\Livewire\Dashboard\MyListings;
 use App\Livewire\Dashboard\MyProperties;
 use App\Livewire\Dashboard\PropertyForm;
+use App\Livewire\Dashboard\ProfileSettings;
 use App\Livewire\Public\Browse;
 use App\Livewire\Public\Home;
 use App\Livewire\Public\Show;
@@ -20,6 +21,7 @@ Route::middleware('auth')->prefix('dashboard')->name('dashboard.')->group(functi
     Route::get('/properties/{id}/edit', PropertyForm::class)->name('properties.edit');
     Route::get('/listings', MyListings::class)->name('listings.index');
     Route::get('/connections', MyConnections::class)->name('connections.index');
+    Route::get('/settings', ProfileSettings::class)->name('settings');
 });
 
 Route::get('/dashboard', Dashboard::class)

--- a/tests/Feature/Dashboard/ProfileSettingsTest.php
+++ b/tests/Feature/Dashboard/ProfileSettingsTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use App\Livewire\Dashboard\ProfileSettings;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+
+test('guests are redirected to login', function () {
+    $this->get(route('dashboard.settings'))->assertRedirect(route('login'));
+});
+
+test('mount fills in the current user\'s details', function () {
+    $user = User::factory()->create(['name' => 'Jane Doe', 'email' => 'jane@example.com', 'phone' => '5551234']);
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->assertSet('name', 'Jane Doe')
+        ->assertSet('email', 'jane@example.com')
+        ->assertSet('phone', '5551234');
+});
+
+test('a user can update their name, email, and phone', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->set('name', 'Updated Name')
+        ->set('email', 'updated@example.com')
+        ->set('phone', '9998887777')
+        ->call('updateProfile')
+        ->assertSet('statusMessage', 'Profile updated.');
+
+    expect($user->fresh())
+        ->name->toBe('Updated Name')
+        ->email->toBe('updated@example.com')
+        ->phone->toBe('9998887777');
+});
+
+test('email must be unique among other users', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create(['email' => 'taken@example.com']);
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->set('email', 'taken@example.com')
+        ->call('updateProfile')
+        ->assertHasErrors(['email']);
+});
+
+test('a user can upload a new avatar and the old one is deleted', function () {
+    Storage::fake('public');
+    $user = User::factory()->create(['avatar' => 'avatars/old.jpg']);
+    Storage::disk('public')->put('avatars/old.jpg', 'fake-content');
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->set('avatar', UploadedFile::fake()->image('new.jpg'))
+        ->call('updateProfile');
+
+    Storage::disk('public')->assertMissing('avatars/old.jpg');
+    expect($user->fresh()->avatar)->not->toBeNull();
+});
+
+test('a user can update their password with the correct current password', function () {
+    $user = User::factory()->create(['password' => Hash::make('old-password')]);
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->set('current_password', 'old-password')
+        ->set('password', 'new-password')
+        ->set('password_confirmation', 'new-password')
+        ->call('updatePassword')
+        ->assertSet('passwordStatusMessage', 'Password updated.');
+
+    expect(Hash::check('new-password', $user->fresh()->password))->toBeTrue();
+});
+
+test('updating the password fails with an incorrect current password', function () {
+    $user = User::factory()->create(['password' => Hash::make('old-password')]);
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->set('current_password', 'wrong-password')
+        ->set('password', 'new-password')
+        ->set('password_confirmation', 'new-password')
+        ->call('updatePassword')
+        ->assertHasErrors(['current_password']);
+
+    expect(Hash::check('old-password', $user->fresh()->password))->toBeTrue();
+});
+
+test('a user can delete their account with the correct password', function () {
+    $user = User::factory()->create(['password' => Hash::make('correct-password')]);
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->set('delete_password', 'correct-password')
+        ->call('deleteAccount')
+        ->assertRedirect(route('home'));
+
+    expect(User::find($user->id))->toBeNull();
+    expect(User::withTrashed()->find($user->id)->trashed())->toBeTrue();
+});
+
+test('deleting the account fails with an incorrect password and the account is kept', function () {
+    $user = User::factory()->create(['password' => Hash::make('correct-password')]);
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->set('delete_password', 'wrong-password')
+        ->call('deleteAccount')
+        ->assertHasErrors(['delete_password']);
+
+    expect($user->fresh())->not->toBeNull();
+});

--- a/tests/Feature/ProfileApiTest.php
+++ b/tests/Feature/ProfileApiTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Sanctum\Sanctum;
+
+test('a user can update their profile via the api', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user);
+
+    $this->putJson('/api/profile', ['name' => 'New Name'])
+        ->assertOk()
+        ->assertJsonPath('name', 'New Name');
+
+    expect($user->fresh()->name)->toBe('New Name');
+});
+
+test('a user can upload an avatar via the api', function () {
+    Storage::fake('public');
+    $user = User::factory()->create();
+    Sanctum::actingAs($user);
+
+    $this->putJson('/api/profile', ['avatar' => UploadedFile::fake()->image('avatar.jpg')])
+        ->assertOk();
+
+    expect($user->fresh()->avatar)->not->toBeNull();
+});
+
+test('email must be unique when updating profile via the api', function () {
+    $user = User::factory()->create();
+    User::factory()->create(['email' => 'taken@example.com']);
+    Sanctum::actingAs($user);
+
+    $this->putJson('/api/profile', ['email' => 'taken@example.com'])
+        ->assertStatus(422);
+});
+
+test('a user can delete their account via the api with the correct password', function () {
+    $user = User::factory()->create(['password' => Hash::make('correct-password')]);
+    Sanctum::actingAs($user);
+
+    $this->deleteJson('/api/profile', ['password' => 'correct-password'])
+        ->assertOk();
+
+    expect(User::find($user->id))->toBeNull();
+    expect(User::withTrashed()->find($user->id)->trashed())->toBeTrue();
+});
+
+test('deleting an account via the api fails with an incorrect password', function () {
+    $user = User::factory()->create(['password' => Hash::make('correct-password')]);
+    Sanctum::actingAs($user);
+
+    $this->deleteJson('/api/profile', ['password' => 'wrong-password'])
+        ->assertStatus(422);
+
+    expect($user->fresh())->not->toBeNull();
+});

--- a/tests/Feature/ProfileApiTest.php
+++ b/tests/Feature/ProfileApiTest.php
@@ -28,6 +28,44 @@ test('a user can upload an avatar via the api', function () {
     expect($user->fresh()->avatar)->not->toBeNull();
 });
 
+test('a user can change their password via the api with the correct current password', function () {
+    $user = User::factory()->create(['password' => Hash::make('old-password')]);
+    Sanctum::actingAs($user);
+
+    $this->putJson('/api/profile', [
+        'current_password' => 'old-password',
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ])->assertOk();
+
+    expect(Hash::check('new-password', $user->fresh()->password))->toBeTrue();
+});
+
+test('changing the password via the api fails without the correct current password', function () {
+    $user = User::factory()->create(['password' => Hash::make('old-password')]);
+    Sanctum::actingAs($user);
+
+    $this->putJson('/api/profile', [
+        'current_password' => 'wrong-password',
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ])->assertStatus(422);
+
+    expect(Hash::check('old-password', $user->fresh()->password))->toBeTrue();
+});
+
+test('changing the password via the api fails without current_password at all', function () {
+    $user = User::factory()->create(['password' => Hash::make('old-password')]);
+    Sanctum::actingAs($user);
+
+    $this->putJson('/api/profile', [
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ])->assertStatus(422);
+
+    expect(Hash::check('old-password', $user->fresh()->password))->toBeTrue();
+});
+
 test('email must be unique when updating profile via the api', function () {
     $user = User::factory()->create();
     User::factory()->create(['email' => 'taken@example.com']);


### PR DESCRIPTION
## Summary
- Covers Figma screens 1.8 (Complete Profile), 1.18 (My Profile/Settings), 1.20 (Logout confirmation), 1.21 (Delete Account).
- New `dashboard.settings` page (`ProfileSettings` Livewire component): edit name/email/phone/avatar, change password, delete account (with password re-confirmation).
- Dashboard shows a "Complete your profile" nudge until the user uploads an avatar.
- Logout forms (app + public layouts) now confirm before submitting.
- New API endpoints for mobile parity: `PUT /api/profile`, `DELETE /api/profile`.
- `User` model: `avatar`/`meta` added to `$fillable`, `meta` cast to `array` (pre-empting the JSON-corruption bug hit earlier with `Property::details`).

## Test plan
- [x] `php artisan test` — full suite passes (93 tests)
- [x] New tests: `tests/Feature/Dashboard/ProfileSettingsTest.php`, `tests/Feature/ProfileApiTest.php`
- [x] Verified live: login, dashboard nudge, settings page (prefilled fields), logout confirm blocks navigation when dismissed

🤖 Generated with [Claude Code](https://claude.com/claude-code)