### PR TITLE
Add Support Tickets dashboard page (1.19)

### DIFF
--- a/app/Livewire/Dashboard/SupportTickets.php
+++ b/app/Livewire/Dashboard/SupportTickets.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Livewire\Dashboard;
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+#[Layout('layouts.app')]
+class SupportTickets extends Component
+{
+    use WithPagination;
+
+    public string $subject = '';
+
+    public string $message = '';
+
+    public bool $showForm = false;
+
+    public function createTicket(): void
+    {
+        $validated = $this->validate([
+            'subject' => 'required|string|max:255',
+            'message' => 'required|string',
+        ]);
+
+        auth()->user()->supportTickets()->create($validated);
+
+        $this->reset('subject', 'message', 'showForm');
+    }
+
+    public function render()
+    {
+        $tickets = auth()->user()->supportTickets()->latest()->paginate(10);
+
+        return view('livewire.dashboard.support-tickets', [
+            'tickets' => $tickets,
+        ]);
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -19,6 +19,7 @@
                     <a href="{{ route('dashboard.properties.index') }}" class="text-gray-600 hover:text-green-700">My Properties</a>
                     <a href="{{ route('dashboard.listings.index') }}" class="text-gray-600 hover:text-green-700">My Listings</a>
                     <a href="{{ route('dashboard.connections.index') }}" class="text-gray-600 hover:text-green-700">My Connections</a>
+                    <a href="{{ route('dashboard.support.index') }}" class="text-gray-600 hover:text-green-700">Support</a>
                     <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-green-700">Browse properties</a>
 
                     <form method="POST" action="{{ route('logout') }}">

--- a/resources/views/livewire/dashboard/support-tickets.blade.php
+++ b/resources/views/livewire/dashboard/support-tickets.blade.php
@@ -1,0 +1,69 @@
+<div class="space-y-6">
+    <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold text-gray-900">Report a Problem</h1>
+
+        <button type="button" wire:click="$toggle('showForm')" class="rounded-md bg-green-700 px-4 py-2 text-sm font-semibold text-white hover:bg-green-800">
+            {{ $showForm ? 'Cancel' : 'New ticket' }}
+        </button>
+    </div>
+
+    @if ($showForm)
+        <form wire:submit="createTicket" class="space-y-4 rounded-lg border border-gray-200 bg-white p-6">
+            <div>
+                <x-input-label for="subject" value="Subject" />
+                <x-text-input wire:model="subject" id="subject" type="text" />
+                <x-input-error :messages="$errors->get('subject')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="message" value="Describe the problem" />
+                <textarea wire:model="message" id="message" rows="4" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500"></textarea>
+                <x-input-error :messages="$errors->get('message')" class="mt-2" />
+            </div>
+
+            <button type="submit" class="rounded-md bg-green-700 px-6 py-2 text-sm font-semibold text-white hover:bg-green-800">
+                Submit ticket
+            </button>
+        </form>
+    @endif
+
+    @if ($tickets->isEmpty())
+        <p class="text-gray-500">You haven't reported any problems yet.</p>
+    @else
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+            <table class="w-full text-left text-sm">
+                <thead class="border-b border-gray-200 bg-gray-50 text-gray-500">
+                    <tr>
+                        <th class="px-4 py-3">Subject</th>
+                        <th class="px-4 py-3">Status</th>
+                        <th class="px-4 py-3">Submitted</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    @foreach ($tickets as $ticket)
+                        <tr wire:key="ticket-{{ $ticket->id }}">
+                            <td class="px-4 py-3">
+                                <div class="font-medium text-gray-900">{{ $ticket->subject }}</div>
+                                <div class="text-gray-500">{{ \Illuminate\Support\Str::limit($ticket->message, 80) }}</div>
+                            </td>
+                            <td class="px-4 py-3">
+                                <span class="rounded-full px-2 py-0.5 text-xs font-medium {{ match ($ticket->status) {
+                                    'open' => 'bg-amber-50 text-amber-700',
+                                    'in_progress' => 'bg-blue-50 text-blue-700',
+                                    'resolved' => 'bg-green-50 text-green-700',
+                                    'closed' => 'bg-gray-100 text-gray-600',
+                                    default => 'bg-gray-100 text-gray-600',
+                                } }}">
+                                    {{ ucfirst(str_replace('_', ' ', $ticket->status)) }}
+                                </span>
+                            </td>
+                            <td class="px-4 py-3 text-gray-500">{{ $ticket->created_at->format('M j, Y') }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+
+        {{ $tickets->links() }}
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Livewire\Dashboard\MyConnections;
 use App\Livewire\Dashboard\MyListings;
 use App\Livewire\Dashboard\MyProperties;
 use App\Livewire\Dashboard\PropertyForm;
+use App\Livewire\Dashboard\SupportTickets;
 use App\Livewire\Public\Browse;
 use App\Livewire\Public\Home;
 use App\Livewire\Public\Show;
@@ -20,6 +21,7 @@ Route::middleware('auth')->prefix('dashboard')->name('dashboard.')->group(functi
     Route::get('/properties/{id}/edit', PropertyForm::class)->name('properties.edit');
     Route::get('/listings', MyListings::class)->name('listings.index');
     Route::get('/connections', MyConnections::class)->name('connections.index');
+    Route::get('/support', SupportTickets::class)->name('support.index');
 });
 
 Route::get('/dashboard', Dashboard::class)

--- a/tests/Feature/Dashboard/SupportTicketsTest.php
+++ b/tests/Feature/Dashboard/SupportTicketsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Livewire\Dashboard\SupportTickets;
+use App\Models\SupportTicket;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('guests are redirected to login', function () {
+    $this->get(route('dashboard.support.index'))->assertRedirect(route('login'));
+});
+
+test('only the authenticated user\'s own tickets are listed', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    SupportTicket::factory()->create(['user_id' => $user->id, 'subject' => 'My problem']);
+    SupportTicket::factory()->create(['user_id' => $other->id, 'subject' => 'Their problem']);
+
+    Livewire::actingAs($user)
+        ->test(SupportTickets::class)
+        ->assertSee('My problem')
+        ->assertDontSee('Their problem');
+});
+
+test('a user can create a support ticket', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(SupportTickets::class)
+        ->set('subject', 'App keeps crashing')
+        ->set('message', 'It crashes every time I open the listings page.')
+        ->call('createTicket')
+        ->assertSet('showForm', false);
+
+    expect(SupportTicket::where('user_id', $user->id)->where('subject', 'App keeps crashing')->exists())->toBeTrue();
+});
+
+test('subject and message are required', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(SupportTickets::class)
+        ->set('subject', '')
+        ->set('message', '')
+        ->call('createTicket')
+        ->assertHasErrors(['subject', 'message']);
+});
+
+test('ticket status is shown', function () {
+    $user = User::factory()->create();
+    SupportTicket::factory()->create(['user_id' => $user->id, 'status' => 'resolved']);
+
+    Livewire::actingAs($user)
+        ->test(SupportTickets::class)
+        ->assertSee('Resolved');
+});


### PR DESCRIPTION
## Summary
- Covers Figma screen 1.19 (Report a Problem). The API (`SupportTicketController`) already existed for the mobile app; this adds the equivalent web dashboard page.
- New `dashboard.support.index` page (`SupportTickets` Livewire component): list of the user's own tickets with status badges (open/in_progress/resolved/closed), and a toggleable "New ticket" form.
- Nav link added to `layouts/app.blade.php`.

## Test plan
- [x] `php artisan test` — full suite passes (84 tests)
- [x] New tests: `tests/Feature/Dashboard/SupportTicketsTest.php`
- [x] Verified live: created a ticket through the UI, confirmed it appears at the top of the list with "Open" status; confirmed only the logged-in user's own tickets are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)