### PR TITLE
Add owner-initiated connections (1.9/1.15)

### DIFF
--- a/app/Filament/Agency/Resources/ConnectionResource.php
+++ b/app/Filament/Agency/Resources/ConnectionResource.php
@@ -5,9 +5,11 @@ namespace App\Filament\Agency\Resources;
 use App\Filament\Agency\Resources\ConnectionResource\Pages;
 use App\Models\Connection;
 use App\Models\Property;
+use App\Services\ConnectionService;
 use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Forms\Form;
+use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -67,6 +69,11 @@ class ConnectionResource extends Resource
                 Tables\Columns\TextColumn::make('target_phone')
                     ->label('Target Phone')
                     ->placeholder('—'),
+                Tables\Columns\TextColumn::make('initiated_by')
+                    ->label('Requested by')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state) => $state === 'owner' ? 'Owner' : 'Us')
+                    ->color(fn (string $state) => $state === 'owner' ? 'info' : 'gray'),
                 Tables\Columns\TextColumn::make('status')
                     ->badge()
                     ->color(fn (string $state) => match ($state) {
@@ -90,9 +97,33 @@ class ConnectionResource extends Resource
                     'rejected' => 'Rejected',
                     'expired' => 'Expired',
                 ]),
+                Tables\Filters\SelectFilter::make('initiated_by')
+                    ->label('Requested by')
+                    ->options([
+                        'owner' => 'Owner',
+                        'agency' => 'Us',
+                    ]),
             ])
             ->actions([
                 Tables\Actions\ViewAction::make(),
+                Tables\Actions\Action::make('accept')
+                    ->visible(fn (Connection $record) => $record->initiated_by === 'owner' && $record->status === 'pending')
+                    ->requiresConfirmation()
+                    ->color('success')
+                    ->action(function (Connection $record) {
+                        app(ConnectionService::class)->acceptAsAgency($record, Filament::auth()->user());
+
+                        Notification::make()->title('Connection accepted')->success()->send();
+                    }),
+                Tables\Actions\Action::make('reject')
+                    ->visible(fn (Connection $record) => $record->initiated_by === 'owner' && $record->status === 'pending')
+                    ->requiresConfirmation()
+                    ->color('danger')
+                    ->action(function (Connection $record) {
+                        app(ConnectionService::class)->rejectAsAgency($record, Filament::auth()->user());
+
+                        Notification::make()->title('Connection rejected')->success()->send();
+                    }),
             ]);
     }
 

--- a/app/Filament/Agency/Resources/ConnectionResource/Pages/CreateConnection.php
+++ b/app/Filament/Agency/Resources/ConnectionResource/Pages/CreateConnection.php
@@ -13,6 +13,7 @@ class CreateConnection extends CreateRecord
     protected function mutateFormDataBeforeCreate(array $data): array
     {
         $data['agency_id'] = Filament::auth()->id();
+        $data['initiated_by'] = 'agency';
         $data['status'] = 'pending';
 
         return $data;

--- a/app/Http/Controllers/Api/ConnectionController.php
+++ b/app/Http/Controllers/Api/ConnectionController.php
@@ -4,7 +4,9 @@ namespace App\Http\Controllers\Api;
 
 use App\Exceptions\ConnectionActionException;
 use App\Http\Controllers\Controller;
+use App\Models\Agency;
 use App\Models\Connection;
+use App\Models\Property;
 use App\Services\ConnectionService;
 use Illuminate\Http\Request;
 
@@ -47,6 +49,7 @@ class ConnectionController extends Controller
 
         $connection = Connection::create([
             'agency_id' => $agency->id,
+            'initiated_by' => 'agency',
             'property_id' => $validated['property_id'] ?? null,
             'target_phone' => $validated['target_phone'] ?? null,
             'message' => $validated['message'] ?? null,
@@ -55,6 +58,62 @@ class ConnectionController extends Controller
         ]);
 
         return response()->json($connection, 201);
+    }
+
+    /**
+     * Property owner initiates a connection request to an agency.
+     */
+    public function initiate(Request $request)
+    {
+        $user = $request->user();
+
+        $validated = $request->validate([
+            'property_id' => 'required|integer|exists:properties,id',
+            'agency_id' => 'required|integer|exists:agencies,id',
+            'message' => 'nullable|string',
+        ]);
+
+        $property = Property::findOrFail($validated['property_id']);
+        $agency = Agency::findOrFail($validated['agency_id']);
+
+        try {
+            $connection = $this->connections->initiate($user, $property, $agency, $validated['message'] ?? null);
+        } catch (ConnectionActionException $e) {
+            return response()->json(['message' => $e->getMessage()], $e->status);
+        }
+
+        return response()->json($connection, 201);
+    }
+
+    /**
+     * Agency accepts a pending, owner-initiated connection request.
+     */
+    public function agencyAccept(Request $request, $id)
+    {
+        return $this->respondAsAgency($request, $id, true);
+    }
+
+    /**
+     * Agency rejects a pending, owner-initiated connection request.
+     */
+    public function agencyReject(Request $request, $id)
+    {
+        return $this->respondAsAgency($request, $id, false);
+    }
+
+    private function respondAsAgency(Request $request, $id, bool $accepted)
+    {
+        $connection = Connection::with('property')->findOrFail($id);
+
+        try {
+            $connection = $accepted
+                ? $this->connections->acceptAsAgency($connection, $request->user())
+                : $this->connections->rejectAsAgency($connection, $request->user());
+        } catch (ConnectionActionException $e) {
+            return response()->json(['message' => $e->getMessage()], $e->status);
+        }
+
+        return response()->json($connection);
     }
 
     /**

--- a/app/Livewire/Dashboard/MyConnections.php
+++ b/app/Livewire/Dashboard/MyConnections.php
@@ -3,8 +3,10 @@
 namespace App\Livewire\Dashboard;
 
 use App\Exceptions\ConnectionActionException;
+use App\Models\Agency;
 use App\Services\ConnectionService;
 use Livewire\Attributes\Layout;
+use Livewire\Attributes\Url;
 use Livewire\Component;
 use Livewire\WithPagination;
 
@@ -13,7 +15,26 @@ class MyConnections extends Component
 {
     use WithPagination;
 
+    #[Url]
+    public string $tab = 'received';
+
     public ?string $error = null;
+
+    public bool $showForm = false;
+
+    public string $property_id = '';
+
+    public string $agency_id = '';
+
+    public string $message = '';
+
+    public ?string $formError = null;
+
+    public function setTab(string $tab): void
+    {
+        $this->tab = $tab;
+        $this->resetPage();
+    }
 
     public function accept(int $connectionId): void
     {
@@ -38,15 +59,39 @@ class MyConnections extends Component
         }
     }
 
+    public function sendRequest(): void
+    {
+        $validated = $this->validate([
+            'property_id' => 'required|integer',
+            'agency_id' => 'required|integer',
+            'message' => 'nullable|string',
+        ]);
+
+        $property = auth()->user()->properties()->findOrFail($validated['property_id']);
+        $agency = Agency::findOrFail($validated['agency_id']);
+
+        try {
+            app(ConnectionService::class)->initiate(auth()->user(), $property, $agency, $validated['message'] ?: null);
+            $this->reset('property_id', 'agency_id', 'message', 'showForm');
+            $this->formError = null;
+            $this->setTab('sent');
+        } catch (ConnectionActionException $e) {
+            $this->formError = $e->getMessage();
+        }
+    }
+
     public function render()
     {
-        $connections = app(ConnectionService::class)->mine(auth()->user())
-            ->with(['property', 'agency'])
-            ->latest()
-            ->paginate(10);
+        $connections = app(ConnectionService::class);
+
+        $query = $this->tab === 'sent'
+            ? $connections->sentByMe(auth()->user())
+            : $connections->mine(auth()->user());
 
         return view('livewire.dashboard.my-connections', [
-            'connections' => $connections,
+            'connections' => $query->with(['property', 'agency'])->latest()->paginate(10),
+            'properties' => auth()->user()->properties()->orderBy('title')->get(),
+            'agencies' => Agency::orderBy('name')->limit(50)->get(),
         ]);
     }
 }

--- a/app/Services/ConnectionService.php
+++ b/app/Services/ConnectionService.php
@@ -3,44 +3,109 @@
 namespace App\Services;
 
 use App\Exceptions\ConnectionActionException;
+use App\Models\Agency;
 use App\Models\Connection;
+use App\Models\Property;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 
 class ConnectionService
 {
     /**
-     * Base query for connections aimed at properties owned by the given user.
+     * Base query for agency-initiated connections aimed at properties owned by the given user
+     * — i.e. incoming requests the owner can accept/reject.
      */
     public function mine(User $user): Builder
     {
         return Connection::whereHas('property', function ($q) use ($user) {
             $q->where('user_id', $user->id);
-        });
+        })->where('initiated_by', 'agency');
     }
 
     /**
-     * Property owner accepts a pending connection request.
+     * Base query for connections the given owner has sent to agencies — read-only,
+     * awaiting the agency's response.
+     */
+    public function sentByMe(User $user): Builder
+    {
+        return Connection::whereHas('property', function ($q) use ($user) {
+            $q->where('user_id', $user->id);
+        })->where('initiated_by', 'owner');
+    }
+
+    /**
+     * Property owner initiates a connection request to an agency.
+     */
+    public function initiate(User $user, Property $property, Agency $agency, ?string $message): Connection
+    {
+        if ($property->user_id !== $user->id) {
+            throw new ConnectionActionException('You do not own this property.', 403);
+        }
+
+        return Connection::create([
+            'agency_id' => $agency->id,
+            'property_id' => $property->id,
+            'initiated_by' => 'owner',
+            'message' => $message,
+            'status' => 'pending',
+        ]);
+    }
+
+    /**
+     * Property owner accepts a pending, agency-initiated connection request.
      */
     public function accept(Connection $connection, User $user): Connection
-    {
-        return $this->respond($connection, $user, 'accepted');
-    }
-
-    /**
-     * Property owner rejects a pending connection request.
-     */
-    public function reject(Connection $connection, User $user): Connection
-    {
-        return $this->respond($connection, $user, 'rejected');
-    }
-
-    private function respond(Connection $connection, User $user, string $newStatus): Connection
     {
         if (! $connection->property || $connection->property->user_id !== $user->id) {
             throw new ConnectionActionException('You do not own the property this connection is for.', 403);
         }
 
+        return $this->respond($connection, 'accepted');
+    }
+
+    /**
+     * Property owner rejects a pending, agency-initiated connection request.
+     */
+    public function reject(Connection $connection, User $user): Connection
+    {
+        if (! $connection->property || $connection->property->user_id !== $user->id) {
+            throw new ConnectionActionException('You do not own the property this connection is for.', 403);
+        }
+
+        return $this->respond($connection, 'rejected');
+    }
+
+    /**
+     * Agency accepts a pending, owner-initiated connection request.
+     */
+    public function acceptAsAgency(Connection $connection, Agency $agency): Connection
+    {
+        return $this->respondAsAgency($connection, $agency, 'accepted');
+    }
+
+    /**
+     * Agency rejects a pending, owner-initiated connection request.
+     */
+    public function rejectAsAgency(Connection $connection, Agency $agency): Connection
+    {
+        return $this->respondAsAgency($connection, $agency, 'rejected');
+    }
+
+    private function respondAsAgency(Connection $connection, Agency $agency, string $newStatus): Connection
+    {
+        if ($connection->agency_id !== $agency->id) {
+            throw new ConnectionActionException('You do not own this connection.', 403);
+        }
+
+        if ($connection->initiated_by !== 'owner') {
+            throw new ConnectionActionException('Only owner-initiated connection requests can be responded to here.', 403);
+        }
+
+        return $this->respond($connection, $newStatus);
+    }
+
+    private function respond(Connection $connection, string $newStatus): Connection
+    {
         if ($connection->expires_at && $connection->expires_at->isPast() && $connection->status === 'pending') {
             $connection->update(['status' => 'expired']);
         }

--- a/database/migrations/2026_08_07_072126_add_initiated_by_to_connections_table.php
+++ b/database/migrations/2026_08_07_072126_add_initiated_by_to_connections_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('connections', function (Blueprint $table) {
+            $table->enum('initiated_by', ['agency', 'owner'])->default('agency')->after('agency_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('connections', function (Blueprint $table) {
+            $table->dropColumn('initiated_by');
+        });
+    }
+};

--- a/resources/views/livewire/dashboard/my-connections.blade.php
+++ b/resources/views/livewire/dashboard/my-connections.blade.php
@@ -1,5 +1,11 @@
 <div class="space-y-6">
-    <h1 class="text-2xl font-semibold text-gray-900">My Connections</h1>
+    <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold text-gray-900">My Connections</h1>
+
+        <button type="button" wire:click="$toggle('showForm')" class="rounded-md bg-green-700 px-4 py-2 text-sm font-semibold text-white hover:bg-green-800">
+            {{ $showForm ? 'Cancel' : 'Connect with an agency' }}
+        </button>
+    </div>
 
     @if ($error)
         <div class="rounded-md bg-red-50 p-3 text-sm text-red-700">
@@ -7,8 +13,71 @@
         </div>
     @endif
 
+    @if ($showForm)
+        <form wire:submit="sendRequest" class="space-y-4 rounded-lg border border-gray-200 bg-white p-6">
+            @if ($formError)
+                <div class="rounded-md bg-red-50 p-3 text-sm text-red-700">{{ $formError }}</div>
+            @endif
+
+            <div>
+                <x-input-label for="property_id" value="Property" />
+                <select wire:model="property_id" id="property_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500">
+                    <option value="">Select a property&hellip;</option>
+                    @foreach ($properties as $property)
+                        <option value="{{ $property->id }}">{{ $property->title }}</option>
+                    @endforeach
+                </select>
+                <x-input-error :messages="$errors->get('property_id')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="agency_id" value="Agency" />
+                <select wire:model="agency_id" id="agency_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500">
+                    <option value="">Select an agency&hellip;</option>
+                    @foreach ($agencies as $agency)
+                        <option value="{{ $agency->id }}">{{ $agency->name }}</option>
+                    @endforeach
+                </select>
+                <x-input-error :messages="$errors->get('agency_id')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="message" value="Message (optional)" />
+                <textarea wire:model="message" id="message" rows="3" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500"></textarea>
+                <x-input-error :messages="$errors->get('message')" class="mt-2" />
+            </div>
+
+            <button type="submit" class="rounded-md bg-green-700 px-6 py-2 text-sm font-semibold text-white hover:bg-green-800">
+                Send request
+            </button>
+        </form>
+    @endif
+
+    <div class="flex gap-6 border-b border-gray-200 text-sm font-medium">
+        <button
+            type="button"
+            wire:click="setTab('received')"
+            class="border-b-2 px-1 py-2 {{ $tab === 'received' ? 'border-green-700 text-green-700' : 'border-transparent text-gray-500 hover:text-gray-700' }}"
+        >
+            From Agencies
+        </button>
+        <button
+            type="button"
+            wire:click="setTab('sent')"
+            class="border-b-2 px-1 py-2 {{ $tab === 'sent' ? 'border-green-700 text-green-700' : 'border-transparent text-gray-500 hover:text-gray-700' }}"
+        >
+            Sent by Me
+        </button>
+    </div>
+
     @if ($connections->isEmpty())
-        <p class="text-gray-500">No agency has reached out about your properties yet.</p>
+        <p class="text-gray-500">
+            @if ($tab === 'sent')
+                You haven't reached out to any agencies yet.
+            @else
+                No agency has reached out about your properties yet.
+            @endif
+        </p>
     @else
         <div class="space-y-4">
             @foreach ($connections as $connection)
@@ -17,7 +86,9 @@
                         <div>
                             <div class="font-medium text-gray-900">{{ $connection->property->title }}</div>
                             <div class="text-sm text-gray-500">{{ $connection->property->location }}</div>
-                            <div class="mt-1 text-sm text-gray-700">From {{ $connection->agency->name }}</div>
+                            <div class="mt-1 text-sm text-gray-700">
+                                {{ $tab === 'sent' ? 'To' : 'From' }} {{ $connection->agency->name }}
+                            </div>
                         </div>
 
                         <span class="shrink-0 rounded-full px-2 py-0.5 text-xs font-medium {{ match ($connection->status) {
@@ -34,7 +105,7 @@
                         <p class="mt-3 text-sm text-gray-600">&ldquo;{{ $connection->message }}&rdquo;</p>
                     @endif
 
-                    @if ($connection->status === 'pending')
+                    @if ($tab === 'received' && $connection->status === 'pending')
                         <div class="mt-4">
                             <button
                                 type="button"

--- a/routes/api.php
+++ b/routes/api.php
@@ -43,6 +43,7 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::prefix('connections')->group(function () {
     Route::get('/', [ConnectionController::class, 'index']); // connections aimed at my properties
+    Route::post('/', [ConnectionController::class, 'initiate']); // owner initiates a connection to an agency
     Route::post('/{id}/accept', [ConnectionController::class, 'accept']);
     Route::post('/{id}/reject', [ConnectionController::class, 'reject']);
     });
@@ -70,5 +71,7 @@ Route::prefix('agency')->middleware('agency.api_key')->group(function () {
     Route::prefix('connections')->group(function () {
     Route::get('/', [ConnectionController::class, 'indexForAgency']);
     Route::post('/', [ConnectionController::class, 'store']); // initiate a connection
+    Route::post('/{id}/accept', [ConnectionController::class, 'agencyAccept']); // respond to an owner-initiated request
+    Route::post('/{id}/reject', [ConnectionController::class, 'agencyReject']);
     });
 });

--- a/tests/Feature/ConnectionApiTest.php
+++ b/tests/Feature/ConnectionApiTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Agency;
 use App\Models\Connection;
 use App\Models\Property;
 use App\Models\User;
@@ -82,4 +83,67 @@ test('index only returns connections on the authenticated user\'s properties', f
 
     $response->assertOk();
     expect($response->json('data'))->toHaveCount(1);
+});
+
+test('an owner can initiate a connection to an agency via the api', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    Sanctum::actingAs($owner);
+
+    $this->postJson('/api/connections', [
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'message' => 'Interested in listing.',
+    ])
+        ->assertCreated()
+        ->assertJsonPath('initiated_by', 'owner')
+        ->assertJsonPath('status', 'pending');
+});
+
+test('an owner cannot initiate a connection for a property they do not own via the api', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    Sanctum::actingAs($intruder);
+
+    $this->postJson('/api/connections', [
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+    ])->assertForbidden();
+});
+
+test('an agency can accept an owner-initiated connection via the api', function () {
+    $agency = Agency::factory()->create();
+    $apiKey = \App\Models\AgencyApiKey::factory()->create(['agency_id' => $agency->id]);
+    $property = Property::factory()->create();
+    $connection = Connection::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'initiated_by' => 'owner',
+    ]);
+
+    $this->withHeader('X-Agency-Api-Key', $apiKey->api_key)
+        ->postJson("/api/agency/connections/{$connection->id}/accept")
+        ->assertOk()
+        ->assertJsonPath('status', 'accepted');
+});
+
+test('an agency cannot accept another agency\'s owner-initiated connection via the api', function () {
+    $agency = Agency::factory()->create();
+    $intruderAgency = Agency::factory()->create();
+    $apiKey = \App\Models\AgencyApiKey::factory()->create(['agency_id' => $intruderAgency->id]);
+    $property = Property::factory()->create();
+    $connection = Connection::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'initiated_by' => 'owner',
+    ]);
+
+    $this->withHeader('X-Agency-Api-Key', $apiKey->api_key)
+        ->postJson("/api/agency/connections/{$connection->id}/accept")
+        ->assertForbidden();
 });

--- a/tests/Feature/ConnectionServiceTest.php
+++ b/tests/Feature/ConnectionServiceTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Exceptions\ConnectionActionException;
+use App\Models\Agency;
 use App\Models\Connection;
 use App\Models\Property;
 use App\Models\User;
@@ -85,4 +86,108 @@ test('mine() only returns connections on the given user\'s properties', function
     Connection::factory()->create(['property_id' => $otherProperty->id]);
 
     expect(app(ConnectionService::class)->mine($owner)->count())->toBe(1);
+});
+
+test('mine() excludes owner-initiated connections', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+
+    Connection::factory()->create(['property_id' => $property->id, 'initiated_by' => 'owner']);
+    Connection::factory()->create(['property_id' => $property->id, 'initiated_by' => 'agency']);
+
+    expect(app(ConnectionService::class)->mine($owner)->count())->toBe(1);
+});
+
+test('sentByMe() only returns owner-initiated connections on the given user\'s properties', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+
+    $ownProperty = Property::factory()->create(['user_id' => $owner->id]);
+    $otherProperty = Property::factory()->create(['user_id' => $other->id]);
+
+    Connection::factory()->create(['property_id' => $ownProperty->id, 'initiated_by' => 'owner']);
+    Connection::factory()->create(['property_id' => $ownProperty->id, 'initiated_by' => 'agency']);
+    Connection::factory()->create(['property_id' => $otherProperty->id, 'initiated_by' => 'owner']);
+
+    expect(app(ConnectionService::class)->sentByMe($owner)->count())->toBe(1);
+});
+
+test('an owner can initiate a connection to an agency', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    $connection = app(ConnectionService::class)->initiate($owner, $property, $agency, 'Interested in listing.');
+
+    expect($connection->status)->toBe('pending');
+    expect($connection->initiated_by)->toBe('owner');
+    expect($connection->agency_id)->toBe($agency->id);
+});
+
+test('an owner cannot initiate a connection for a property they do not own', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    expect(fn () => app(ConnectionService::class)->initiate($intruder, $property, $agency, null))
+        ->toThrow(ConnectionActionException::class);
+});
+
+test('an agency can accept an owner-initiated connection', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+    $connection = Connection::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'initiated_by' => 'owner',
+    ]);
+
+    $result = app(ConnectionService::class)->acceptAsAgency($connection, $agency);
+
+    expect($result->status)->toBe('accepted');
+});
+
+test('an agency can reject an owner-initiated connection', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+    $connection = Connection::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'initiated_by' => 'owner',
+    ]);
+
+    $result = app(ConnectionService::class)->rejectAsAgency($connection, $agency);
+
+    expect($result->status)->toBe('rejected');
+});
+
+test('a different agency cannot respond to an owner-initiated connection', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+    $intruderAgency = Agency::factory()->create();
+    $connection = Connection::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'initiated_by' => 'owner',
+    ]);
+
+    expect(fn () => app(ConnectionService::class)->acceptAsAgency($connection, $intruderAgency))
+        ->toThrow(ConnectionActionException::class);
+});
+
+test('an agency cannot respond to its own agency-initiated connection via the agency-response methods', function () {
+    $agency = Agency::factory()->create();
+    $property = Property::factory()->create();
+    $connection = Connection::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'initiated_by' => 'agency',
+    ]);
+
+    expect(fn () => app(ConnectionService::class)->acceptAsAgency($connection, $agency))
+        ->toThrow(ConnectionActionException::class);
 });

--- a/tests/Feature/Dashboard/MyConnectionsTest.php
+++ b/tests/Feature/Dashboard/MyConnectionsTest.php
@@ -103,3 +103,77 @@ test('agency name and message are shown for each connection', function () {
         ->assertSee('Best Realtors')
         ->assertSee('We would love to list this property.');
 });
+
+test('an owner-initiated connection does not appear on the received tab', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id, 'title' => 'My House']);
+    Connection::factory()->create(['property_id' => $property->id, 'initiated_by' => 'owner']);
+
+    Livewire::actingAs($owner)
+        ->test(MyConnections::class)
+        ->set('tab', 'received')
+        ->assertDontSee('My House');
+});
+
+test('the sent tab only shows connections the owner initiated', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create(['name' => 'Best Realtors']);
+    Connection::factory()->create(['property_id' => $property->id, 'agency_id' => $agency->id, 'initiated_by' => 'owner']);
+    Connection::factory()->create(['property_id' => $property->id, 'initiated_by' => 'agency']);
+
+    $component = Livewire::actingAs($owner)
+        ->test(MyConnections::class)
+        ->set('tab', 'sent');
+
+    expect($component->viewData('connections'))->toHaveCount(1);
+    $component->assertSee('Best Realtors');
+});
+
+test('a sent connection has no accept/reject buttons', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    Connection::factory()->create(['property_id' => $property->id, 'initiated_by' => 'owner']);
+
+    Livewire::actingAs($owner)
+        ->test(MyConnections::class)
+        ->set('tab', 'sent')
+        ->assertDontSee('Accept')
+        ->assertDontSee('Reject');
+});
+
+test('an owner can send a connection request to an agency', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    Livewire::actingAs($owner)
+        ->test(MyConnections::class)
+        ->set('property_id', (string) $property->id)
+        ->set('agency_id', (string) $agency->id)
+        ->set('message', 'Interested in listing this property.')
+        ->call('sendRequest')
+        ->assertSet('tab', 'sent');
+
+    expect(Connection::where('property_id', $property->id)
+        ->where('agency_id', $agency->id)
+        ->where('initiated_by', 'owner')
+        ->exists())->toBeTrue();
+});
+
+test('an owner cannot send a connection request for a property they do not own', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    $this->actingAs($intruder);
+
+    expect(fn () => Livewire::test(MyConnections::class)
+        ->set('property_id', (string) $property->id)
+        ->set('agency_id', (string) $agency->id)
+        ->call('sendRequest'))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    expect(Connection::where('property_id', $property->id)->exists())->toBeFalse();
+});


### PR DESCRIPTION
## Summary
- Covers Figma screens 1.9/1.15 (owner adding/reaching out to an agency). Previously connections could only be initiated by agencies; owners could only accept/reject.
- New `initiated_by` enum column (`agency`|`owner`, default `agency`) on `connections` distinguishes direction.
- `ConnectionService`: `mine()` now scoped to agency-initiated only (incoming requests owners act on); added `sentByMe()` (owner's own outgoing requests, read-only), `initiate()` (owner → agency), and `acceptAsAgency()`/`rejectAsAgency()` (agency responding to an owner-initiated request).
- API: `POST /api/connections` lets an owner initiate a request; `POST /api/agency/connections/{id}/accept|reject` lets an agency respond to one.
- Web: **My Connections** page now has "From Agencies" / "Sent by Me" tabs plus a "Connect with an agency" form (pick one of your properties, pick an agency, optional message).
- Agency Filament panel: `ConnectionResource` shows a "Requested by" badge/filter and Accept/Reject actions for pending owner-initiated requests; the agency's own create form now explicitly tags `initiated_by = agency`.

## Test plan
- [x] `php artisan test` — full suite passes (96 tests)
- [x] New/updated tests: `ConnectionServiceTest`, `ConnectionApiTest`, `Dashboard/MyConnectionsTest`
- [x] Verified live: sent a request from an owner's property to an agency, confirmed it appears under "Sent by Me" as Pending with no accept/reject controls, and that "From Agencies" still shows only the original incoming requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)