### PR TITLE
Add remove-agency action for approved listings (1.10/1.16)

### DIFF
--- a/app/Http/Controllers/Api/ListingController.php
+++ b/app/Http/Controllers/Api/ListingController.php
@@ -93,6 +93,22 @@ class ListingController extends Controller
         return $this->respond($request, $id, false);
     }
 
+    /**
+     * Property owner removes the agency from a previously approved listing.
+     */
+    public function removeAgency(Request $request, $id)
+    {
+        $listing = Listing::with('property')->findOrFail($id);
+
+        try {
+            $listing = $this->listings->removeAgency($listing, $request->user());
+        } catch (ListingActionException $e) {
+            return response()->json(['message' => $e->getMessage()], $e->status);
+        }
+
+        return response()->json($listing);
+    }
+
     private function respond(Request $request, $id, bool $approved)
     {
         $listing = Listing::with('property')->findOrFail($id);

--- a/app/Livewire/Dashboard/MyListings.php
+++ b/app/Livewire/Dashboard/MyListings.php
@@ -25,6 +25,19 @@ class MyListings extends Component
         $this->respond($listingId, false);
     }
 
+    public function removeAgency(int $listingId): void
+    {
+        $listings = app(ListingService::class);
+        $listing = $listings->mine(auth()->user())->with('property')->findOrFail($listingId);
+
+        try {
+            $listings->removeAgency($listing, auth()->user());
+            $this->error = null;
+        } catch (ListingActionException $e) {
+            $this->error = $e->getMessage();
+        }
+    }
+
     private function respond(int $listingId, bool $approved): void
     {
         $listings = app(ListingService::class);

--- a/app/Services/ListingService.php
+++ b/app/Services/ListingService.php
@@ -64,6 +64,38 @@ class ListingService
     }
 
     /**
+     * Property owner removes the agency from a listing that was previously approved,
+     * ending the arrangement without deleting the listing's history.
+     */
+    public function removeAgency(Listing $listing, User $user): Listing
+    {
+        if ($listing->property->user_id !== $user->id) {
+            throw new ListingActionException('You do not own the property this listing is for.', 403);
+        }
+
+        if (! $listing->user_approved) {
+            throw new ListingActionException('This listing has not been approved, so there is no agency to remove.', 409);
+        }
+
+        if ($listing->status === 'archived') {
+            throw new ListingActionException('This listing has already been archived.', 409);
+        }
+
+        $fromStatus = $listing->status;
+
+        $listing->update(['status' => 'archived']);
+
+        $listing->statusHistories()->create([
+            'from_status' => $fromStatus,
+            'to_status' => 'archived',
+            'changed_by_user_id' => $user->id,
+            'reason' => 'Agency removed by property owner.',
+        ]);
+
+        return $listing;
+    }
+
+    /**
      * Agency proposes a listing for a property.
      */
     public function propose(Agency $agency, int $propertyId, ?string $agencyNotes = null): Listing

--- a/resources/views/livewire/dashboard/my-listings.blade.php
+++ b/resources/views/livewire/dashboard/my-listings.blade.php
@@ -57,9 +57,18 @@
                                     >
                                         Reject
                                     </button>
+                                @elseif ($listing->user_approved && $listing->status !== 'archived')
+                                    <button
+                                        type="button"
+                                        wire:click="removeAgency({{ $listing->id }})"
+                                        wire:confirm="Remove this agency from the listing? This will archive the listing."
+                                        class="text-red-600 hover:text-red-800"
+                                    >
+                                        Remove Agency
+                                    </button>
                                 @else
                                     <span class="text-gray-400">
-                                        {{ $listing->user_approved ? 'Approved' : 'Rejected' }}
+                                        {{ $listing->user_approved ? 'Archived' : 'Rejected' }}
                                     </span>
                                 @endif
                             </td>

--- a/routes/api.php
+++ b/routes/api.php
@@ -39,6 +39,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/', [ListingController::class, 'index']); // listings on my properties
     Route::post('/{id}/approve', [ListingController::class, 'approve']);
     Route::post('/{id}/reject', [ListingController::class, 'reject']);
+    Route::post('/{id}/remove-agency', [ListingController::class, 'removeAgency']);
     });
 
     Route::prefix('connections')->group(function () {

--- a/tests/Feature/Dashboard/MyListingsTest.php
+++ b/tests/Feature/Dashboard/MyListingsTest.php
@@ -100,3 +100,47 @@ test('agency name is shown for each listing', function () {
         ->test(MyListings::class)
         ->assertSee('Best Realtors');
 });
+
+test('an approved listing shows a Remove Agency button', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(MyListings::class)
+        ->assertSee('Remove Agency');
+});
+
+test('owner can remove the agency from an approved listing', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(MyListings::class)
+        ->call('removeAgency', $listing->id);
+
+    expect($listing->fresh()->status)->toBe('archived');
+});
+
+test('an archived listing does not show a Remove Agency button', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'archived',
+        'user_approved' => false,
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(MyListings::class)
+        ->assertDontSee('Remove Agency');
+});

--- a/tests/Feature/ListingApiTest.php
+++ b/tests/Feature/ListingApiTest.php
@@ -53,6 +53,47 @@ test('approving an already-responded listing conflicts', function () {
     $this->postJson("/api/listings/{$listing->id}/reject")->assertStatus(409);
 });
 
+test('owner can remove the agency from an approved listing via the api', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+
+    Sanctum::actingAs($owner);
+
+    $this->postJson("/api/listings/{$listing->id}/remove-agency")
+        ->assertOk()
+        ->assertJsonPath('status', 'archived');
+});
+
+test('a non-owner cannot remove the agency from a listing via the api', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+
+    Sanctum::actingAs($intruder);
+
+    $this->postJson("/api/listings/{$listing->id}/remove-agency")->assertForbidden();
+});
+
+test('removing the agency from a listing that was never approved conflicts via the api', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    Sanctum::actingAs($owner);
+
+    $this->postJson("/api/listings/{$listing->id}/remove-agency")->assertStatus(409);
+});
+
 test('index only returns listings on the authenticated user\'s properties', function () {
     $owner = User::factory()->create();
     $other = User::factory()->create();

--- a/tests/Feature/ListingServiceTest.php
+++ b/tests/Feature/ListingServiceTest.php
@@ -51,6 +51,61 @@ test('a listing that has already been responded to cannot be responded to again'
         ->toThrow(ListingActionException::class);
 });
 
+test('owner can remove the agency from an approved listing', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+
+    $result = app(ListingService::class)->removeAgency($listing, $owner);
+
+    expect($result->status)->toBe('archived');
+    expect($listing->statusHistories()->count())->toBe(1);
+});
+
+test('a non-owner cannot remove the agency from a listing', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+
+    expect(fn () => app(ListingService::class)->removeAgency($listing, $intruder))
+        ->toThrow(ListingActionException::class);
+});
+
+test('the agency cannot be removed from a listing that was never approved', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    expect(fn () => app(ListingService::class)->removeAgency($listing, $owner))
+        ->toThrow(ListingActionException::class);
+
+    expect($listing->fresh()->status)->toBe('pending');
+});
+
+test('the agency cannot be removed twice from an already-archived listing', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+
+    app(ListingService::class)->removeAgency($listing, $owner);
+
+    expect(fn () => app(ListingService::class)->removeAgency($listing->fresh(), $owner))
+        ->toThrow(ListingActionException::class);
+});
+
 test('mine() only returns listings on the given user\'s properties', function () {
     $owner = User::factory()->create();
     $other = User::factory()->create();


### PR DESCRIPTION
## Summary
- Covers Figma screens 1.10/1.16 (removing/editing the agency on a listing). Previously an owner could only approve/reject a newly-proposed listing; there was no way to end an already-approved arrangement.
- `ListingService::removeAgency()`: archives the listing and records a `ListingStatusHistory` entry, guarded so it only applies to listings that are approved (`user_approved = true`) and not already archived.
- API: `POST /api/listings/{id}/remove-agency`.
- Web: **My Listings** page now shows a "Remove Agency" action for any approved, non-archived listing (available/rented/sold), replacing the Approve/Reject buttons once a listing has moved past the pending state.

## Test plan
- [x] `php artisan test` — full suite passes (89 tests)
- [x] New tests: `ListingServiceTest`, `ListingApiTest`, `Dashboard/MyListingsTest`
- [x] Verified live: manually approved a seeded listing, confirmed "Remove Agency" replaces Approve/Reject on the My Listings page and disappears once archived

🤖 Generated with [Claude Code](https://claude.com/claude-code)