### PR TITLE
Add Notifications dashboard with actionable cards (1.22/1.23/1.24)

### DIFF
--- a/app/Http/Controllers/Api/ConnectionController.php
+++ b/app/Http/Controllers/Api/ConnectionController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\Api;
 use App\Exceptions\ConnectionActionException;
 use App\Http\Controllers\Controller;
 use App\Models\Connection;
+use App\Models\Notification;
+use App\Models\Property;
 use App\Services\ConnectionService;
 use Illuminate\Http\Request;
 
@@ -53,6 +55,19 @@ class ConnectionController extends Controller
             'expires_at' => $validated['expires_at'] ?? null,
             'status' => 'pending',
         ]);
+
+        if ($connection->property_id) {
+            $property = Property::find($connection->property_id);
+
+            if ($property) {
+                Notification::create([
+                    'user_id' => $property->user_id,
+                    'title' => 'New connection request',
+                    'message' => "{$agency->name} wants to connect about {$property->title}.",
+                    'payload' => ['type' => 'connection_request', 'connection_id' => $connection->id],
+                ]);
+            }
+        }
 
         return response()->json($connection, 201);
     }

--- a/app/Livewire/Dashboard/Notifications.php
+++ b/app/Livewire/Dashboard/Notifications.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Livewire\Dashboard;
+
+use App\Exceptions\ConnectionActionException;
+use App\Exceptions\ListingActionException;
+use App\Models\Connection;
+use App\Models\Listing;
+use App\Models\Notification;
+use App\Services\ConnectionService;
+use App\Services\ListingService;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+#[Layout('layouts.app')]
+class Notifications extends Component
+{
+    use WithPagination;
+
+    public ?string $error = null;
+
+    public function markRead(int $notificationId): void
+    {
+        auth()->user()->notifications()->findOrFail($notificationId)->update(['is_read' => true]);
+    }
+
+    public function accept(int $notificationId): void
+    {
+        $this->act($notificationId, true);
+    }
+
+    public function decline(int $notificationId): void
+    {
+        $this->act($notificationId, false);
+    }
+
+    private function act(int $notificationId, bool $accepted): void
+    {
+        $notification = auth()->user()->notifications()->findOrFail($notificationId);
+        $payload = $notification->payload ?? [];
+
+        try {
+            match ($payload['type'] ?? null) {
+                'listing_proposed' => $this->respondToListing($payload['listing_id'], $accepted),
+                'connection_request' => $this->respondToConnection($payload['connection_id'], $accepted),
+                default => throw new ListingActionException('This notification cannot be acted on.', 422),
+            };
+
+            $notification->update(['is_read' => true]);
+            $this->error = null;
+        } catch (ListingActionException|ConnectionActionException $e) {
+            $this->error = $e->getMessage();
+        }
+    }
+
+    private function respondToListing(int $listingId, bool $accepted): void
+    {
+        $listings = app(ListingService::class);
+        $listing = $listings->mine(auth()->user())->findOrFail($listingId);
+
+        $accepted ? $listings->approve($listing, auth()->user()) : $listings->reject($listing, auth()->user());
+    }
+
+    private function respondToConnection(int $connectionId, bool $accepted): void
+    {
+        $connections = app(ConnectionService::class);
+        $connection = $connections->mine(auth()->user())->findOrFail($connectionId);
+
+        $accepted ? $connections->accept($connection, auth()->user()) : $connections->reject($connection, auth()->user());
+    }
+
+    private function isPending(Notification $notification): bool
+    {
+        $payload = $notification->payload ?? [];
+
+        return match ($payload['type'] ?? null) {
+            'listing_proposed' => is_null(optional(Listing::find($payload['listing_id'] ?? null))->user_approved),
+            'connection_request' => optional(Connection::find($payload['connection_id'] ?? null))->status === 'pending',
+            default => false,
+        };
+    }
+
+    public function render()
+    {
+        $notifications = auth()->user()->notifications()->latest()->paginate(15);
+
+        $notifications->each(fn (Notification $notification) => $notification->is_pending = $this->isPending($notification));
+
+        return view('livewire.dashboard.notifications', [
+            'notifications' => $notifications,
+        ]);
+    }
+}

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -11,6 +11,14 @@ class Notification extends Model
 
     protected $guarded = [];
 
+    protected function casts(): array
+    {
+        return [
+            'payload' => 'array',
+            'is_read' => 'boolean',
+        ];
+    }
+
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/app/Services/ListingService.php
+++ b/app/Services/ListingService.php
@@ -5,6 +5,8 @@ namespace App\Services;
 use App\Exceptions\ListingActionException;
 use App\Models\Agency;
 use App\Models\Listing;
+use App\Models\Notification;
+use App\Models\Property;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -79,13 +81,26 @@ class ListingService
             );
         }
 
-        return Listing::create([
+        $listing = Listing::create([
             'property_id' => $propertyId,
             'agency_id' => $agency->id,
             'status' => 'pending',
             'agency_proposed' => true,
             'agency_notes' => $agencyNotes,
         ]);
+
+        $property = Property::find($propertyId);
+
+        if ($property) {
+            Notification::create([
+                'user_id' => $property->user_id,
+                'title' => 'New listing proposal',
+                'message' => "{$agency->name} proposed a listing for {$property->title}.",
+                'payload' => ['type' => 'listing_proposed', 'listing_id' => $listing->id],
+            ]);
+        }
+
+        return $listing;
     }
 
     /**

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -19,6 +19,15 @@
                     <a href="{{ route('dashboard.properties.index') }}" class="text-gray-600 hover:text-green-700">My Properties</a>
                     <a href="{{ route('dashboard.listings.index') }}" class="text-gray-600 hover:text-green-700">My Listings</a>
                     <a href="{{ route('dashboard.connections.index') }}" class="text-gray-600 hover:text-green-700">My Connections</a>
+                    <a href="{{ route('dashboard.notifications.index') }}" class="relative text-gray-600 hover:text-green-700">
+                        Notifications
+                        @php($unreadCount = auth()->user()->notifications()->where('is_read', false)->count())
+                        @if ($unreadCount > 0)
+                            <span class="absolute -right-3 -top-2 rounded-full bg-red-600 px-1.5 py-0.5 text-xs font-semibold text-white">
+                                {{ $unreadCount }}
+                            </span>
+                        @endif
+                    </a>
                     <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-green-700">Browse properties</a>
 
                     <form method="POST" action="{{ route('logout') }}">

--- a/resources/views/livewire/dashboard/notifications.blade.php
+++ b/resources/views/livewire/dashboard/notifications.blade.php
@@ -1,0 +1,67 @@
+<div class="space-y-6">
+    <h1 class="text-2xl font-semibold text-gray-900">Notifications</h1>
+
+    @if ($error)
+        <div class="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            {{ $error }}
+        </div>
+    @endif
+
+    @if ($notifications->isEmpty())
+        <p class="text-gray-500">You don't have any notifications yet.</p>
+    @else
+        <div class="space-y-3">
+            @foreach ($notifications as $notification)
+                <div
+                    wire:key="notification-{{ $notification->id }}"
+                    class="rounded-lg border bg-white p-4 {{ $notification->is_read ? 'border-gray-200' : 'border-green-200 bg-green-50/40' }}"
+                >
+                    <div class="flex items-start justify-between gap-4">
+                        <div>
+                            <div class="flex items-center gap-2">
+                                @unless ($notification->is_read)
+                                    <span class="h-2 w-2 shrink-0 rounded-full bg-green-600"></span>
+                                @endunless
+                                <div class="font-medium text-gray-900">{{ $notification->title }}</div>
+                            </div>
+                            <p class="mt-1 text-sm text-gray-600">{{ $notification->message }}</p>
+                        </div>
+
+                        <span class="shrink-0 text-xs text-gray-400">{{ $notification->created_at->diffForHumans() }}</span>
+                    </div>
+
+                    <div class="mt-4 flex items-center gap-3">
+                        @if ($notification->is_pending)
+                            <button
+                                type="button"
+                                wire:click="accept({{ $notification->id }})"
+                                wire:confirm="Accept this request?"
+                                class="text-green-700 hover:text-green-800"
+                            >
+                                Accept
+                            </button>
+                            <button
+                                type="button"
+                                wire:click="decline({{ $notification->id }})"
+                                wire:confirm="Decline this request?"
+                                class="text-red-600 hover:text-red-800"
+                            >
+                                Decline
+                            </button>
+                        @elseif (! $notification->is_read)
+                            <button
+                                type="button"
+                                wire:click="markRead({{ $notification->id }})"
+                                class="text-sm text-gray-500 hover:text-gray-700"
+                            >
+                                Mark as read
+                            </button>
+                        @endif
+                    </div>
+                </div>
+            @endforeach
+        </div>
+
+        {{ $notifications->links() }}
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Livewire\Dashboard;
 use App\Livewire\Dashboard\MyConnections;
 use App\Livewire\Dashboard\MyListings;
 use App\Livewire\Dashboard\MyProperties;
+use App\Livewire\Dashboard\Notifications;
 use App\Livewire\Dashboard\PropertyForm;
 use App\Livewire\Public\Browse;
 use App\Livewire\Public\Home;
@@ -20,6 +21,7 @@ Route::middleware('auth')->prefix('dashboard')->name('dashboard.')->group(functi
     Route::get('/properties/{id}/edit', PropertyForm::class)->name('properties.edit');
     Route::get('/listings', MyListings::class)->name('listings.index');
     Route::get('/connections', MyConnections::class)->name('connections.index');
+    Route::get('/notifications', Notifications::class)->name('notifications.index');
 });
 
 Route::get('/dashboard', Dashboard::class)

--- a/tests/Feature/ConnectionApiTest.php
+++ b/tests/Feature/ConnectionApiTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Models\Agency;
+use App\Models\AgencyApiKey;
 use App\Models\Connection;
+use App\Models\Notification;
 use App\Models\Property;
 use App\Models\User;
 use Laravel\Sanctum\Sanctum;
@@ -64,6 +67,33 @@ test('a past-expiry connection cannot be accepted and is marked expired', functi
     $this->postJson("/api/connections/{$connection->id}/accept")->assertStatus(409);
 
     expect($connection->fresh()->status)->toBe('expired');
+});
+
+test('an agency initiating a connection on a property notifies its owner', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id, 'title' => 'Cozy Cottage']);
+    $agency = Agency::factory()->create(['name' => 'Best Realtors']);
+    $apiKey = AgencyApiKey::factory()->create(['agency_id' => $agency->id]);
+
+    $response = $this->withHeader('X-Agency-Api-Key', $apiKey->api_key)
+        ->postJson('/api/agency/connections', ['property_id' => $property->id]);
+
+    $response->assertCreated();
+
+    $notification = Notification::where('user_id', $owner->id)->first();
+    expect($notification)->not->toBeNull();
+    expect($notification->payload)->toBe(['type' => 'connection_request', 'connection_id' => $response->json('id')]);
+});
+
+test('an agency initiating a connection to a phone number does not create a notification', function () {
+    $agency = Agency::factory()->create();
+    $apiKey = AgencyApiKey::factory()->create(['agency_id' => $agency->id]);
+
+    $this->withHeader('X-Agency-Api-Key', $apiKey->api_key)
+        ->postJson('/api/agency/connections', ['target_phone' => '555-0100'])
+        ->assertCreated();
+
+    expect(Notification::count())->toBe(0);
 });
 
 test('index only returns connections on the authenticated user\'s properties', function () {

--- a/tests/Feature/Dashboard/NotificationsTest.php
+++ b/tests/Feature/Dashboard/NotificationsTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use App\Livewire\Dashboard\Notifications;
+use App\Models\Connection;
+use App\Models\Listing;
+use App\Models\Notification;
+use App\Models\Property;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('guests are redirected to login', function () {
+    $this->get(route('dashboard.notifications.index'))->assertRedirect(route('login'));
+});
+
+test('only the authenticated user\'s own notifications are listed', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    Notification::factory()->create(['user_id' => $user->id, 'title' => 'My notification']);
+    Notification::factory()->create(['user_id' => $other->id, 'title' => 'Their notification']);
+
+    Livewire::actingAs($user)
+        ->test(Notifications::class)
+        ->assertSee('My notification')
+        ->assertDontSee('Their notification');
+});
+
+test('a listing_proposed notification for a still-pending listing shows accept/decline', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+    Notification::factory()->create([
+        'user_id' => $owner->id,
+        'payload' => ['type' => 'listing_proposed', 'listing_id' => $listing->id],
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(Notifications::class)
+        ->assertSee('Accept')
+        ->assertSee('Decline');
+});
+
+test('accepting a listing_proposed notification approves the listing and marks it read', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+    $notification = Notification::factory()->create([
+        'user_id' => $owner->id,
+        'payload' => ['type' => 'listing_proposed', 'listing_id' => $listing->id],
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(Notifications::class)
+        ->call('accept', $notification->id);
+
+    expect($listing->fresh()->status)->toBe('available');
+    expect($notification->fresh()->is_read)->toBeTrue();
+});
+
+test('declining a connection_request notification rejects the connection', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create(['property_id' => $property->id]);
+    $notification = Notification::factory()->create([
+        'user_id' => $owner->id,
+        'payload' => ['type' => 'connection_request', 'connection_id' => $connection->id],
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(Notifications::class)
+        ->call('decline', $notification->id);
+
+    expect($connection->fresh()->status)->toBe('rejected');
+    expect($notification->fresh()->is_read)->toBeTrue();
+});
+
+test('acting on an already-resolved notification shows an error', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+    $notification = Notification::factory()->create([
+        'user_id' => $owner->id,
+        'payload' => ['type' => 'listing_proposed', 'listing_id' => $listing->id],
+    ]);
+
+    $component = Livewire::actingAs($owner)->test(Notifications::class);
+    $component->call('accept', $notification->id);
+    $component->call('decline', $notification->id);
+
+    expect($component->get('error'))->not->toBeNull();
+});
+
+test('a resolved listing_proposed notification no longer shows accept/decline', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+    Notification::factory()->create([
+        'user_id' => $owner->id,
+        'payload' => ['type' => 'listing_proposed', 'listing_id' => $listing->id],
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(Notifications::class)
+        ->assertDontSee('Accept')
+        ->assertDontSee('Decline');
+});
+
+test('a non-actionable notification can be marked as read', function () {
+    $user = User::factory()->create();
+    $notification = Notification::factory()->create(['user_id' => $user->id]);
+
+    Livewire::actingAs($user)
+        ->test(Notifications::class)
+        ->assertSee('Mark as read')
+        ->call('markRead', $notification->id);
+
+    expect($notification->fresh()->is_read)->toBeTrue();
+});
+
+test('a user cannot mark another user\'s notification as read', function () {
+    $user = User::factory()->create();
+    $intruder = User::factory()->create();
+    $notification = Notification::factory()->create(['user_id' => $user->id]);
+
+    $this->actingAs($intruder);
+
+    expect(fn () => Livewire::test(Notifications::class)->call('markRead', $notification->id))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+});

--- a/tests/Feature/ListingServiceTest.php
+++ b/tests/Feature/ListingServiceTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Exceptions\ListingActionException;
+use App\Models\Agency;
 use App\Models\Listing;
+use App\Models\Notification;
 use App\Models\Property;
 use App\Models\User;
 use App\Services\ListingService;
@@ -49,6 +51,20 @@ test('a listing that has already been responded to cannot be responded to again'
 
     expect(fn () => app(ListingService::class)->reject($listing->fresh(), $owner))
         ->toThrow(ListingActionException::class);
+});
+
+test('proposing a listing notifies the property owner', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id, 'title' => 'Cozy Cottage']);
+    $agency = Agency::factory()->create(['name' => 'Best Realtors']);
+
+    $listing = app(ListingService::class)->propose($agency, $property->id);
+
+    $notification = Notification::where('user_id', $owner->id)->first();
+
+    expect($notification)->not->toBeNull();
+    expect($notification->payload)->toBe(['type' => 'listing_proposed', 'listing_id' => $listing->id]);
+    expect($notification->message)->toContain('Best Realtors')->toContain('Cozy Cottage');
 });
 
 test('mine() only returns listings on the given user\'s properties', function () {


### PR DESCRIPTION
## Summary
- Covers Figma screens 1.22 (Notifications), and resolves 1.23/1.24 (actionable notification cards).
- The `notifications` table and API (`NotificationController::index`/`markRead`) already existed, but nothing in the app ever created a notification — this wires up the two owner-facing triggers:
  - An agency proposing a listing (`ListingService::propose()`) now notifies the property owner (`payload: {type: listing_proposed, listing_id}`).
  - An agency initiating a connection on a property (`ConnectionController::store`, agency-side) now notifies the property owner (`payload: {type: connection_request, connection_id}`). Connections to a bare phone number (no registered owner) don't create a notification, since there's no user to notify.
- Fixed `Notification::payload` missing its `array` cast — same JSON-corruption bug hit earlier with `Property::details` and `User::meta`, caught this time before any bad data could be written.
- New **Notifications** dashboard page: cards for `listing_proposed`/`connection_request` show inline Accept/Decline, routed through the existing `ListingService`/`ConnectionService` methods (same logic the My Listings/My Connections pages use, so there's one source of truth). Once the underlying listing/connection is resolved elsewhere, the card falls back to a plain "Mark as read". Nav link includes an unread-count badge.

## Test plan
- [x] `php artisan test` — full suite passes (91 tests)
- [x] New/updated tests: `ListingServiceTest`, `ConnectionApiTest`, `Dashboard/NotificationsTest`
- [x] Verified live: seeded a listing_proposed, connection_request, and plain notification; confirmed correct actions render for each, "Mark as read" works and the nav badge count updates on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)