### PR TITLE
Sync develop into main

### DIFF
--- a/app/Filament/Agency/Resources/ConnectionResource.php
+++ b/app/Filament/Agency/Resources/ConnectionResource.php
@@ -5,9 +5,11 @@ namespace App\Filament\Agency\Resources;
 use App\Filament\Agency\Resources\ConnectionResource\Pages;
 use App\Models\Connection;
 use App\Models\Property;
+use App\Services\ConnectionService;
 use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Forms\Form;
+use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -67,6 +69,11 @@ class ConnectionResource extends Resource
                 Tables\Columns\TextColumn::make('target_phone')
                     ->label('Target Phone')
                     ->placeholder('—'),
+                Tables\Columns\TextColumn::make('initiated_by')
+                    ->label('Requested by')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state) => $state === 'owner' ? 'Owner' : 'Us')
+                    ->color(fn (string $state) => $state === 'owner' ? 'info' : 'gray'),
                 Tables\Columns\TextColumn::make('status')
                     ->badge()
                     ->color(fn (string $state) => match ($state) {
@@ -90,9 +97,33 @@ class ConnectionResource extends Resource
                     'rejected' => 'Rejected',
                     'expired' => 'Expired',
                 ]),
+                Tables\Filters\SelectFilter::make('initiated_by')
+                    ->label('Requested by')
+                    ->options([
+                        'owner' => 'Owner',
+                        'agency' => 'Us',
+                    ]),
             ])
             ->actions([
                 Tables\Actions\ViewAction::make(),
+                Tables\Actions\Action::make('accept')
+                    ->visible(fn (Connection $record) => $record->initiated_by === 'owner' && $record->status === 'pending')
+                    ->requiresConfirmation()
+                    ->color('success')
+                    ->action(function (Connection $record) {
+                        app(ConnectionService::class)->acceptAsAgency($record, Filament::auth()->user());
+
+                        Notification::make()->title('Connection accepted')->success()->send();
+                    }),
+                Tables\Actions\Action::make('reject')
+                    ->visible(fn (Connection $record) => $record->initiated_by === 'owner' && $record->status === 'pending')
+                    ->requiresConfirmation()
+                    ->color('danger')
+                    ->action(function (Connection $record) {
+                        app(ConnectionService::class)->rejectAsAgency($record, Filament::auth()->user());
+
+                        Notification::make()->title('Connection rejected')->success()->send();
+                    }),
             ]);
     }
 

--- a/app/Filament/Agency/Resources/ConnectionResource/Pages/CreateConnection.php
+++ b/app/Filament/Agency/Resources/ConnectionResource/Pages/CreateConnection.php
@@ -13,6 +13,7 @@ class CreateConnection extends CreateRecord
     protected function mutateFormDataBeforeCreate(array $data): array
     {
         $data['agency_id'] = Filament::auth()->id();
+        $data['initiated_by'] = 'agency';
         $data['status'] = 'pending';
 
         return $data;

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidationException;
 
 class AuthController extends Controller
@@ -60,6 +61,61 @@ class AuthController extends Controller
     public function profile(Request $request)
     {
         return response()->json($request->user());
+    }
+
+    /**
+     * Update the authenticated user's own profile.
+     */
+    public function updateProfile(Request $request)
+    {
+        $user = $request->user();
+
+        $validated = $request->validate([
+            'name' => 'sometimes|required|string|max:255',
+            'email' => 'sometimes|required|email|max:255|unique:users,email,'.$user->id,
+            'phone' => 'sometimes|required|string|max:255|unique:users,phone,'.$user->id,
+            'password' => 'sometimes|required|string|min:6|confirmed',
+            'avatar' => 'sometimes|nullable|image|max:2048',
+        ]);
+
+        if (isset($validated['password'])) {
+            $validated['password'] = Hash::make($validated['password']);
+        }
+
+        if ($request->hasFile('avatar')) {
+            if ($user->avatar) {
+                Storage::disk('public')->delete($user->avatar);
+            }
+
+            $validated['avatar'] = $request->file('avatar')->store('avatars', 'public');
+        }
+
+        $user->update($validated);
+
+        return response()->json($user->fresh());
+    }
+
+    /**
+     * Delete (soft-delete) the authenticated user's own account.
+     */
+    public function destroyAccount(Request $request)
+    {
+        $request->validate([
+            'password' => 'required|string',
+        ]);
+
+        $user = $request->user();
+
+        if (! Hash::check($request->password, $user->password)) {
+            throw ValidationException::withMessages([
+                'password' => ['The provided password is incorrect.'],
+            ]);
+        }
+
+        $user->tokens()->delete();
+        $user->delete();
+
+        return response()->json(['message' => 'Account deleted successfully']);
     }
 
     public function logout(Request $request)

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -74,13 +74,22 @@ class AuthController extends Controller
             'name' => 'sometimes|required|string|max:255',
             'email' => 'sometimes|required|email|max:255|unique:users,email,'.$user->id,
             'phone' => 'sometimes|required|string|max:255|unique:users,phone,'.$user->id,
+            'current_password' => 'required_with:password|string',
             'password' => 'sometimes|required|string|min:6|confirmed',
             'avatar' => 'sometimes|nullable|image|max:2048',
         ]);
 
         if (isset($validated['password'])) {
+            if (! Hash::check($validated['current_password'], $user->password)) {
+                throw ValidationException::withMessages([
+                    'current_password' => ['The provided password is incorrect.'],
+                ]);
+            }
+
             $validated['password'] = Hash::make($validated['password']);
         }
+
+        unset($validated['current_password']);
 
         if ($request->hasFile('avatar')) {
             if ($user->avatar) {

--- a/app/Http/Controllers/Api/ConnectionController.php
+++ b/app/Http/Controllers/Api/ConnectionController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\Api;
 use App\Exceptions\ConnectionActionException;
 use App\Http\Controllers\Controller;
 use App\Models\Connection;
+use App\Models\Notification;
+use App\Models\Property;
 use App\Services\ConnectionService;
 use Illuminate\Http\Request;
 
@@ -53,6 +55,19 @@ class ConnectionController extends Controller
             'expires_at' => $validated['expires_at'] ?? null,
             'status' => 'pending',
         ]);
+
+        if ($connection->property_id) {
+            $property = Property::find($connection->property_id);
+
+            if ($property) {
+                Notification::create([
+                    'user_id' => $property->user_id,
+                    'title' => 'New connection request',
+                    'message' => "{$agency->name} wants to connect about {$property->title}.",
+                    'payload' => ['type' => 'connection_request', 'connection_id' => $connection->id],
+                ]);
+            }
+        }
 
         return response()->json($connection, 201);
     }

--- a/app/Http/Controllers/Api/ConnectionController.php
+++ b/app/Http/Controllers/Api/ConnectionController.php
@@ -4,7 +4,9 @@ namespace App\Http\Controllers\Api;
 
 use App\Exceptions\ConnectionActionException;
 use App\Http\Controllers\Controller;
+use App\Models\Agency;
 use App\Models\Connection;
+use App\Models\Property;
 use App\Services\ConnectionService;
 use Illuminate\Http\Request;
 
@@ -47,6 +49,7 @@ class ConnectionController extends Controller
 
         $connection = Connection::create([
             'agency_id' => $agency->id,
+            'initiated_by' => 'agency',
             'property_id' => $validated['property_id'] ?? null,
             'target_phone' => $validated['target_phone'] ?? null,
             'message' => $validated['message'] ?? null,
@@ -55,6 +58,62 @@ class ConnectionController extends Controller
         ]);
 
         return response()->json($connection, 201);
+    }
+
+    /**
+     * Property owner initiates a connection request to an agency.
+     */
+    public function initiate(Request $request)
+    {
+        $user = $request->user();
+
+        $validated = $request->validate([
+            'property_id' => 'required|integer|exists:properties,id',
+            'agency_id' => 'required|integer|exists:agencies,id',
+            'message' => 'nullable|string',
+        ]);
+
+        $property = Property::findOrFail($validated['property_id']);
+        $agency = Agency::findOrFail($validated['agency_id']);
+
+        try {
+            $connection = $this->connections->initiate($user, $property, $agency, $validated['message'] ?? null);
+        } catch (ConnectionActionException $e) {
+            return response()->json(['message' => $e->getMessage()], $e->status);
+        }
+
+        return response()->json($connection, 201);
+    }
+
+    /**
+     * Agency accepts a pending, owner-initiated connection request.
+     */
+    public function agencyAccept(Request $request, $id)
+    {
+        return $this->respondAsAgency($request, $id, true);
+    }
+
+    /**
+     * Agency rejects a pending, owner-initiated connection request.
+     */
+    public function agencyReject(Request $request, $id)
+    {
+        return $this->respondAsAgency($request, $id, false);
+    }
+
+    private function respondAsAgency(Request $request, $id, bool $accepted)
+    {
+        $connection = Connection::with('property')->findOrFail($id);
+
+        try {
+            $connection = $accepted
+                ? $this->connections->acceptAsAgency($connection, $request->user())
+                : $this->connections->rejectAsAgency($connection, $request->user());
+        } catch (ConnectionActionException $e) {
+            return response()->json(['message' => $e->getMessage()], $e->status);
+        }
+
+        return response()->json($connection);
     }
 
     /**

--- a/app/Http/Controllers/Api/ListingController.php
+++ b/app/Http/Controllers/Api/ListingController.php
@@ -93,6 +93,22 @@ class ListingController extends Controller
         return $this->respond($request, $id, false);
     }
 
+    /**
+     * Property owner removes the agency from a previously approved listing.
+     */
+    public function removeAgency(Request $request, $id)
+    {
+        $listing = Listing::with('property')->findOrFail($id);
+
+        try {
+            $listing = $this->listings->removeAgency($listing, $request->user());
+        } catch (ListingActionException $e) {
+            return response()->json(['message' => $e->getMessage()], $e->status);
+        }
+
+        return response()->json($listing);
+    }
+
     private function respond(Request $request, $id, bool $approved)
     {
         $listing = Listing::with('property')->findOrFail($id);

--- a/app/Livewire/Dashboard/MyConnections.php
+++ b/app/Livewire/Dashboard/MyConnections.php
@@ -3,8 +3,10 @@
 namespace App\Livewire\Dashboard;
 
 use App\Exceptions\ConnectionActionException;
+use App\Models\Agency;
 use App\Services\ConnectionService;
 use Livewire\Attributes\Layout;
+use Livewire\Attributes\Url;
 use Livewire\Component;
 use Livewire\WithPagination;
 
@@ -13,7 +15,26 @@ class MyConnections extends Component
 {
     use WithPagination;
 
+    #[Url]
+    public string $tab = 'received';
+
     public ?string $error = null;
+
+    public bool $showForm = false;
+
+    public string $property_id = '';
+
+    public string $agency_id = '';
+
+    public string $message = '';
+
+    public ?string $formError = null;
+
+    public function setTab(string $tab): void
+    {
+        $this->tab = $tab;
+        $this->resetPage();
+    }
 
     public function accept(int $connectionId): void
     {
@@ -38,15 +59,39 @@ class MyConnections extends Component
         }
     }
 
+    public function sendRequest(): void
+    {
+        $validated = $this->validate([
+            'property_id' => 'required|integer',
+            'agency_id' => 'required|integer',
+            'message' => 'nullable|string',
+        ]);
+
+        $property = auth()->user()->properties()->findOrFail($validated['property_id']);
+        $agency = Agency::findOrFail($validated['agency_id']);
+
+        try {
+            app(ConnectionService::class)->initiate(auth()->user(), $property, $agency, $validated['message'] ?: null);
+            $this->reset('property_id', 'agency_id', 'message', 'showForm');
+            $this->formError = null;
+            $this->setTab('sent');
+        } catch (ConnectionActionException $e) {
+            $this->formError = $e->getMessage();
+        }
+    }
+
     public function render()
     {
-        $connections = app(ConnectionService::class)->mine(auth()->user())
-            ->with(['property', 'agency'])
-            ->latest()
-            ->paginate(10);
+        $connections = app(ConnectionService::class);
+
+        $query = $this->tab === 'sent'
+            ? $connections->sentByMe(auth()->user())
+            : $connections->mine(auth()->user());
 
         return view('livewire.dashboard.my-connections', [
-            'connections' => $connections,
+            'connections' => $query->with(['property', 'agency'])->latest()->paginate(10),
+            'properties' => auth()->user()->properties()->orderBy('title')->get(),
+            'agencies' => Agency::orderBy('name')->limit(50)->get(),
         ]);
     }
 }

--- a/app/Livewire/Dashboard/MyListings.php
+++ b/app/Livewire/Dashboard/MyListings.php
@@ -25,6 +25,19 @@ class MyListings extends Component
         $this->respond($listingId, false);
     }
 
+    public function removeAgency(int $listingId): void
+    {
+        $listings = app(ListingService::class);
+        $listing = $listings->mine(auth()->user())->with('property')->findOrFail($listingId);
+
+        try {
+            $listings->removeAgency($listing, auth()->user());
+            $this->error = null;
+        } catch (ListingActionException $e) {
+            $this->error = $e->getMessage();
+        }
+    }
+
     private function respond(int $listingId, bool $approved): void
     {
         $listings = app(ListingService::class);

--- a/app/Livewire/Dashboard/Notifications.php
+++ b/app/Livewire/Dashboard/Notifications.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Livewire\Dashboard;
+
+use App\Exceptions\ConnectionActionException;
+use App\Exceptions\ListingActionException;
+use App\Models\Connection;
+use App\Models\Listing;
+use App\Models\Notification;
+use App\Services\ConnectionService;
+use App\Services\ListingService;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+#[Layout('layouts.app')]
+class Notifications extends Component
+{
+    use WithPagination;
+
+    public ?string $error = null;
+
+    public function markRead(int $notificationId): void
+    {
+        auth()->user()->notifications()->findOrFail($notificationId)->update(['is_read' => true]);
+    }
+
+    public function accept(int $notificationId): void
+    {
+        $this->act($notificationId, true);
+    }
+
+    public function decline(int $notificationId): void
+    {
+        $this->act($notificationId, false);
+    }
+
+    private function act(int $notificationId, bool $accepted): void
+    {
+        $notification = auth()->user()->notifications()->findOrFail($notificationId);
+        $payload = $notification->payload ?? [];
+
+        try {
+            match ($payload['type'] ?? null) {
+                'listing_proposed' => $this->respondToListing($payload['listing_id'], $accepted),
+                'connection_request' => $this->respondToConnection($payload['connection_id'], $accepted),
+                default => throw new ListingActionException('This notification cannot be acted on.', 422),
+            };
+
+            $notification->update(['is_read' => true]);
+            $this->error = null;
+        } catch (ListingActionException|ConnectionActionException $e) {
+            $this->error = $e->getMessage();
+        }
+    }
+
+    private function respondToListing(int $listingId, bool $accepted): void
+    {
+        $listings = app(ListingService::class);
+        $listing = $listings->mine(auth()->user())->findOrFail($listingId);
+
+        $accepted ? $listings->approve($listing, auth()->user()) : $listings->reject($listing, auth()->user());
+    }
+
+    private function respondToConnection(int $connectionId, bool $accepted): void
+    {
+        $connections = app(ConnectionService::class);
+        $connection = $connections->mine(auth()->user())->findOrFail($connectionId);
+
+        $accepted ? $connections->accept($connection, auth()->user()) : $connections->reject($connection, auth()->user());
+    }
+
+    private function isPending(Notification $notification): bool
+    {
+        $payload = $notification->payload ?? [];
+
+        return match ($payload['type'] ?? null) {
+            'listing_proposed' => is_null(optional(Listing::find($payload['listing_id'] ?? null))->user_approved),
+            'connection_request' => optional(Connection::find($payload['connection_id'] ?? null))->status === 'pending',
+            default => false,
+        };
+    }
+
+    public function render()
+    {
+        $notifications = auth()->user()->notifications()->latest()->paginate(15);
+
+        $notifications->each(fn (Notification $notification) => $notification->is_pending = $this->isPending($notification));
+
+        return view('livewire.dashboard.notifications', [
+            'notifications' => $notifications,
+        ]);
+    }
+}

--- a/app/Livewire/Dashboard/ProfileSettings.php
+++ b/app/Livewire/Dashboard/ProfileSettings.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Livewire\Dashboard;
+
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Rule;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+
+#[Layout('layouts.app')]
+class ProfileSettings extends Component
+{
+    use WithFileUploads;
+
+    public string $name = '';
+
+    public string $email = '';
+
+    public string $phone = '';
+
+    public $avatar = null;
+
+    public ?string $statusMessage = null;
+
+    public string $current_password = '';
+
+    public string $password = '';
+
+    public string $password_confirmation = '';
+
+    public ?string $passwordStatusMessage = null;
+
+    public string $delete_password = '';
+
+    public function mount(): void
+    {
+        $user = auth()->user();
+
+        $this->name = $user->name;
+        $this->email = $user->email;
+        $this->phone = $user->phone;
+    }
+
+    public function updateProfile(): void
+    {
+        $user = auth()->user();
+
+        $validated = $this->validate([
+            'name' => 'required|string|max:255',
+            'email' => ['required', 'email', 'max:255', Rule::unique('users', 'email')->ignore($user->id)],
+            'phone' => ['required', 'string', 'max:255', Rule::unique('users', 'phone')->ignore($user->id)],
+            'avatar' => 'nullable|image|max:2048',
+        ]);
+
+        if ($this->avatar) {
+            if ($user->avatar) {
+                Storage::disk('public')->delete($user->avatar);
+            }
+
+            $validated['avatar'] = $this->avatar->store('avatars', 'public');
+        } else {
+            unset($validated['avatar']);
+        }
+
+        $user->update($validated);
+
+        $this->avatar = null;
+        $this->statusMessage = 'Profile updated.';
+    }
+
+    public function updatePassword(): void
+    {
+        $user = auth()->user();
+
+        $validated = $this->validate([
+            'current_password' => 'required|string',
+            'password' => 'required|string|min:6|confirmed',
+        ]);
+
+        if (! Hash::check($validated['current_password'], $user->password)) {
+            $this->addError('current_password', 'The current password is incorrect.');
+
+            return;
+        }
+
+        $user->update(['password' => Hash::make($validated['password'])]);
+
+        $this->current_password = '';
+        $this->password = '';
+        $this->password_confirmation = '';
+        $this->passwordStatusMessage = 'Password updated.';
+    }
+
+    public function deleteAccount(): void
+    {
+        $user = auth()->user();
+
+        $this->validate(['delete_password' => 'required|string']);
+
+        if (! Hash::check($this->delete_password, $user->password)) {
+            $this->addError('delete_password', 'The password is incorrect.');
+
+            return;
+        }
+
+        $user->delete();
+
+        auth()->guard('web')->logout();
+        session()->invalidate();
+        session()->regenerateToken();
+
+        $this->redirect(route('home'), navigate: true);
+    }
+
+    public function render()
+    {
+        return view('livewire.dashboard.profile-settings');
+    }
+}

--- a/app/Livewire/Dashboard/SupportTickets.php
+++ b/app/Livewire/Dashboard/SupportTickets.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Livewire\Dashboard;
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+#[Layout('layouts.app')]
+class SupportTickets extends Component
+{
+    use WithPagination;
+
+    public string $subject = '';
+
+    public string $message = '';
+
+    public bool $showForm = false;
+
+    public function createTicket(): void
+    {
+        $validated = $this->validate([
+            'subject' => 'required|string|max:255',
+            'message' => 'required|string',
+        ]);
+
+        auth()->user()->supportTickets()->create($validated);
+
+        $this->reset('subject', 'message', 'showForm');
+    }
+
+    public function render()
+    {
+        $tickets = auth()->user()->supportTickets()->latest()->paginate(10);
+
+        return view('livewire.dashboard.support-tickets', [
+            'tickets' => $tickets,
+        ]);
+    }
+}

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -11,6 +11,14 @@ class Notification extends Model
 
     protected $guarded = [];
 
+    protected function casts(): array
+    {
+        return [
+            'payload' => 'array',
+            'is_read' => 'boolean',
+        ];
+    }
+
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,7 +23,9 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
-        'phone'
+        'phone',
+        'avatar',
+        'meta',
     ];
 
     /**
@@ -46,6 +48,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'meta' => 'array',
         ];
     }
 

--- a/app/Services/ConnectionService.php
+++ b/app/Services/ConnectionService.php
@@ -3,44 +3,109 @@
 namespace App\Services;
 
 use App\Exceptions\ConnectionActionException;
+use App\Models\Agency;
 use App\Models\Connection;
+use App\Models\Property;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 
 class ConnectionService
 {
     /**
-     * Base query for connections aimed at properties owned by the given user.
+     * Base query for agency-initiated connections aimed at properties owned by the given user
+     * — i.e. incoming requests the owner can accept/reject.
      */
     public function mine(User $user): Builder
     {
         return Connection::whereHas('property', function ($q) use ($user) {
             $q->where('user_id', $user->id);
-        });
+        })->where('initiated_by', 'agency');
     }
 
     /**
-     * Property owner accepts a pending connection request.
+     * Base query for connections the given owner has sent to agencies — read-only,
+     * awaiting the agency's response.
+     */
+    public function sentByMe(User $user): Builder
+    {
+        return Connection::whereHas('property', function ($q) use ($user) {
+            $q->where('user_id', $user->id);
+        })->where('initiated_by', 'owner');
+    }
+
+    /**
+     * Property owner initiates a connection request to an agency.
+     */
+    public function initiate(User $user, Property $property, Agency $agency, ?string $message): Connection
+    {
+        if ($property->user_id !== $user->id) {
+            throw new ConnectionActionException('You do not own this property.', 403);
+        }
+
+        return Connection::create([
+            'agency_id' => $agency->id,
+            'property_id' => $property->id,
+            'initiated_by' => 'owner',
+            'message' => $message,
+            'status' => 'pending',
+        ]);
+    }
+
+    /**
+     * Property owner accepts a pending, agency-initiated connection request.
      */
     public function accept(Connection $connection, User $user): Connection
-    {
-        return $this->respond($connection, $user, 'accepted');
-    }
-
-    /**
-     * Property owner rejects a pending connection request.
-     */
-    public function reject(Connection $connection, User $user): Connection
-    {
-        return $this->respond($connection, $user, 'rejected');
-    }
-
-    private function respond(Connection $connection, User $user, string $newStatus): Connection
     {
         if (! $connection->property || $connection->property->user_id !== $user->id) {
             throw new ConnectionActionException('You do not own the property this connection is for.', 403);
         }
 
+        return $this->respond($connection, 'accepted');
+    }
+
+    /**
+     * Property owner rejects a pending, agency-initiated connection request.
+     */
+    public function reject(Connection $connection, User $user): Connection
+    {
+        if (! $connection->property || $connection->property->user_id !== $user->id) {
+            throw new ConnectionActionException('You do not own the property this connection is for.', 403);
+        }
+
+        return $this->respond($connection, 'rejected');
+    }
+
+    /**
+     * Agency accepts a pending, owner-initiated connection request.
+     */
+    public function acceptAsAgency(Connection $connection, Agency $agency): Connection
+    {
+        return $this->respondAsAgency($connection, $agency, 'accepted');
+    }
+
+    /**
+     * Agency rejects a pending, owner-initiated connection request.
+     */
+    public function rejectAsAgency(Connection $connection, Agency $agency): Connection
+    {
+        return $this->respondAsAgency($connection, $agency, 'rejected');
+    }
+
+    private function respondAsAgency(Connection $connection, Agency $agency, string $newStatus): Connection
+    {
+        if ($connection->agency_id !== $agency->id) {
+            throw new ConnectionActionException('You do not own this connection.', 403);
+        }
+
+        if ($connection->initiated_by !== 'owner') {
+            throw new ConnectionActionException('Only owner-initiated connection requests can be responded to here.', 403);
+        }
+
+        return $this->respond($connection, $newStatus);
+    }
+
+    private function respond(Connection $connection, string $newStatus): Connection
+    {
         if ($connection->expires_at && $connection->expires_at->isPast() && $connection->status === 'pending') {
             $connection->update(['status' => 'expired']);
         }

--- a/app/Services/ListingService.php
+++ b/app/Services/ListingService.php
@@ -64,6 +64,38 @@ class ListingService
     }
 
     /**
+     * Property owner removes the agency from a listing that was previously approved,
+     * ending the arrangement without deleting the listing's history.
+     */
+    public function removeAgency(Listing $listing, User $user): Listing
+    {
+        if ($listing->property->user_id !== $user->id) {
+            throw new ListingActionException('You do not own the property this listing is for.', 403);
+        }
+
+        if (! $listing->user_approved) {
+            throw new ListingActionException('This listing has not been approved, so there is no agency to remove.', 409);
+        }
+
+        if ($listing->status === 'archived') {
+            throw new ListingActionException('This listing has already been archived.', 409);
+        }
+
+        $fromStatus = $listing->status;
+
+        $listing->update(['status' => 'archived']);
+
+        $listing->statusHistories()->create([
+            'from_status' => $fromStatus,
+            'to_status' => 'archived',
+            'changed_by_user_id' => $user->id,
+            'reason' => 'Agency removed by property owner.',
+        ]);
+
+        return $listing;
+    }
+
+    /**
      * Agency proposes a listing for a property.
      */
     public function propose(Agency $agency, int $propertyId, ?string $agencyNotes = null): Listing

--- a/app/Services/ListingService.php
+++ b/app/Services/ListingService.php
@@ -5,6 +5,8 @@ namespace App\Services;
 use App\Exceptions\ListingActionException;
 use App\Models\Agency;
 use App\Models\Listing;
+use App\Models\Notification;
+use App\Models\Property;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -79,13 +81,26 @@ class ListingService
             );
         }
 
-        return Listing::create([
+        $listing = Listing::create([
             'property_id' => $propertyId,
             'agency_id' => $agency->id,
             'status' => 'pending',
             'agency_proposed' => true,
             'agency_notes' => $agencyNotes,
         ]);
+
+        $property = Property::find($propertyId);
+
+        if ($property) {
+            Notification::create([
+                'user_id' => $property->user_id,
+                'title' => 'New listing proposal',
+                'message' => "{$agency->name} proposed a listing for {$property->title}.",
+                'payload' => ['type' => 'listing_proposed', 'listing_id' => $listing->id],
+            ]);
+        }
+
+        return $listing;
     }
 
     /**

--- a/database/migrations/2026_08_07_072126_add_initiated_by_to_connections_table.php
+++ b/database/migrations/2026_08_07_072126_add_initiated_by_to_connections_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('connections', function (Blueprint $table) {
+            $table->enum('initiated_by', ['agency', 'owner'])->default('agency')->after('agency_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('connections', function (Blueprint $table) {
+            $table->dropColumn('initiated_by');
+        });
+    }
+};

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -20,8 +20,9 @@
                     <a href="{{ route('dashboard.listings.index') }}" class="text-gray-600 hover:text-green-700">My Listings</a>
                     <a href="{{ route('dashboard.connections.index') }}" class="text-gray-600 hover:text-green-700">My Connections</a>
                     <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-green-700">Browse properties</a>
+                    <a href="{{ route('dashboard.settings') }}" class="text-gray-600 hover:text-green-700">Settings</a>
 
-                    <form method="POST" action="{{ route('logout') }}">
+                    <form method="POST" action="{{ route('logout') }}" onsubmit="return confirm('Are you sure you want to log out?');">
                         @csrf
                         <button type="submit" class="text-gray-600 hover:text-green-700">Log out</button>
                     </form>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -19,6 +19,15 @@
                     <a href="{{ route('dashboard.properties.index') }}" class="text-gray-600 hover:text-green-700">My Properties</a>
                     <a href="{{ route('dashboard.listings.index') }}" class="text-gray-600 hover:text-green-700">My Listings</a>
                     <a href="{{ route('dashboard.connections.index') }}" class="text-gray-600 hover:text-green-700">My Connections</a>
+                    <a href="{{ route('dashboard.notifications.index') }}" class="relative text-gray-600 hover:text-green-700">
+                        Notifications
+                        @php($unreadCount = auth()->user()->notifications()->where('is_read', false)->count())
+                        @if ($unreadCount > 0)
+                            <span class="absolute -right-3 -top-2 rounded-full bg-red-600 px-1.5 py-0.5 text-xs font-semibold text-white">
+                                {{ $unreadCount }}
+                            </span>
+                        @endif
+                    </a>
                     <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-green-700">Browse properties</a>
 
                     <form method="POST" action="{{ route('logout') }}">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -19,6 +19,7 @@
                     <a href="{{ route('dashboard.properties.index') }}" class="text-gray-600 hover:text-green-700">My Properties</a>
                     <a href="{{ route('dashboard.listings.index') }}" class="text-gray-600 hover:text-green-700">My Listings</a>
                     <a href="{{ route('dashboard.connections.index') }}" class="text-gray-600 hover:text-green-700">My Connections</a>
+                    <a href="{{ route('dashboard.support.index') }}" class="text-gray-600 hover:text-green-700">Support</a>
                     <a href="{{ route('properties.index') }}" class="text-gray-600 hover:text-green-700">Browse properties</a>
 
                     <form method="POST" action="{{ route('logout') }}">

--- a/resources/views/layouts/public.blade.php
+++ b/resources/views/layouts/public.blade.php
@@ -20,7 +20,7 @@
                     @auth
                         <a href="{{ route('dashboard') }}" class="text-gray-600 hover:text-green-700">Dashboard</a>
 
-                        <form method="POST" action="{{ route('logout') }}">
+                        <form method="POST" action="{{ route('logout') }}" onsubmit="return confirm('Are you sure you want to log out?');">
                             @csrf
                             <button type="submit" class="text-gray-600 hover:text-green-700">Log out</button>
                         </form>

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -4,4 +4,16 @@
         Manage your properties from
         <a href="{{ route('dashboard.properties.index') }}" class="font-medium text-green-700 hover:text-green-800">My Properties</a>.
     </p>
+
+    @unless (auth()->user()->avatar)
+        <div class="mt-6 flex items-center justify-between rounded-lg border border-green-200 bg-green-50 p-4">
+            <div>
+                <p class="font-medium text-green-900">Complete your profile</p>
+                <p class="text-sm text-green-700">Add a profile photo so agencies and owners recognize you.</p>
+            </div>
+            <a href="{{ route('dashboard.settings') }}" class="rounded-md bg-green-700 px-4 py-2 text-sm font-semibold text-white hover:bg-green-800">
+                Complete profile
+            </a>
+        </div>
+    @endunless
 </div>

--- a/resources/views/livewire/dashboard/my-connections.blade.php
+++ b/resources/views/livewire/dashboard/my-connections.blade.php
@@ -1,5 +1,11 @@
 <div class="space-y-6">
-    <h1 class="text-2xl font-semibold text-gray-900">My Connections</h1>
+    <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold text-gray-900">My Connections</h1>
+
+        <button type="button" wire:click="$toggle('showForm')" class="rounded-md bg-green-700 px-4 py-2 text-sm font-semibold text-white hover:bg-green-800">
+            {{ $showForm ? 'Cancel' : 'Connect with an agency' }}
+        </button>
+    </div>
 
     @if ($error)
         <div class="rounded-md bg-red-50 p-3 text-sm text-red-700">
@@ -7,8 +13,71 @@
         </div>
     @endif
 
+    @if ($showForm)
+        <form wire:submit="sendRequest" class="space-y-4 rounded-lg border border-gray-200 bg-white p-6">
+            @if ($formError)
+                <div class="rounded-md bg-red-50 p-3 text-sm text-red-700">{{ $formError }}</div>
+            @endif
+
+            <div>
+                <x-input-label for="property_id" value="Property" />
+                <select wire:model="property_id" id="property_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500">
+                    <option value="">Select a property&hellip;</option>
+                    @foreach ($properties as $property)
+                        <option value="{{ $property->id }}">{{ $property->title }}</option>
+                    @endforeach
+                </select>
+                <x-input-error :messages="$errors->get('property_id')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="agency_id" value="Agency" />
+                <select wire:model="agency_id" id="agency_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500">
+                    <option value="">Select an agency&hellip;</option>
+                    @foreach ($agencies as $agency)
+                        <option value="{{ $agency->id }}">{{ $agency->name }}</option>
+                    @endforeach
+                </select>
+                <x-input-error :messages="$errors->get('agency_id')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="message" value="Message (optional)" />
+                <textarea wire:model="message" id="message" rows="3" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500"></textarea>
+                <x-input-error :messages="$errors->get('message')" class="mt-2" />
+            </div>
+
+            <button type="submit" class="rounded-md bg-green-700 px-6 py-2 text-sm font-semibold text-white hover:bg-green-800">
+                Send request
+            </button>
+        </form>
+    @endif
+
+    <div class="flex gap-6 border-b border-gray-200 text-sm font-medium">
+        <button
+            type="button"
+            wire:click="setTab('received')"
+            class="border-b-2 px-1 py-2 {{ $tab === 'received' ? 'border-green-700 text-green-700' : 'border-transparent text-gray-500 hover:text-gray-700' }}"
+        >
+            From Agencies
+        </button>
+        <button
+            type="button"
+            wire:click="setTab('sent')"
+            class="border-b-2 px-1 py-2 {{ $tab === 'sent' ? 'border-green-700 text-green-700' : 'border-transparent text-gray-500 hover:text-gray-700' }}"
+        >
+            Sent by Me
+        </button>
+    </div>
+
     @if ($connections->isEmpty())
-        <p class="text-gray-500">No agency has reached out about your properties yet.</p>
+        <p class="text-gray-500">
+            @if ($tab === 'sent')
+                You haven't reached out to any agencies yet.
+            @else
+                No agency has reached out about your properties yet.
+            @endif
+        </p>
     @else
         <div class="space-y-4">
             @foreach ($connections as $connection)
@@ -17,7 +86,9 @@
                         <div>
                             <div class="font-medium text-gray-900">{{ $connection->property->title }}</div>
                             <div class="text-sm text-gray-500">{{ $connection->property->location }}</div>
-                            <div class="mt-1 text-sm text-gray-700">From {{ $connection->agency->name }}</div>
+                            <div class="mt-1 text-sm text-gray-700">
+                                {{ $tab === 'sent' ? 'To' : 'From' }} {{ $connection->agency->name }}
+                            </div>
                         </div>
 
                         <span class="shrink-0 rounded-full px-2 py-0.5 text-xs font-medium {{ match ($connection->status) {
@@ -34,7 +105,7 @@
                         <p class="mt-3 text-sm text-gray-600">&ldquo;{{ $connection->message }}&rdquo;</p>
                     @endif
 
-                    @if ($connection->status === 'pending')
+                    @if ($tab === 'received' && $connection->status === 'pending')
                         <div class="mt-4">
                             <button
                                 type="button"

--- a/resources/views/livewire/dashboard/my-listings.blade.php
+++ b/resources/views/livewire/dashboard/my-listings.blade.php
@@ -57,9 +57,18 @@
                                     >
                                         Reject
                                     </button>
+                                @elseif ($listing->user_approved && $listing->status !== 'archived')
+                                    <button
+                                        type="button"
+                                        wire:click="removeAgency({{ $listing->id }})"
+                                        wire:confirm="Remove this agency from the listing? This will archive the listing."
+                                        class="text-red-600 hover:text-red-800"
+                                    >
+                                        Remove Agency
+                                    </button>
                                 @else
                                     <span class="text-gray-400">
-                                        {{ $listing->user_approved ? 'Approved' : 'Rejected' }}
+                                        {{ $listing->user_approved ? 'Archived' : 'Rejected' }}
                                     </span>
                                 @endif
                             </td>

--- a/resources/views/livewire/dashboard/notifications.blade.php
+++ b/resources/views/livewire/dashboard/notifications.blade.php
@@ -1,0 +1,67 @@
+<div class="space-y-6">
+    <h1 class="text-2xl font-semibold text-gray-900">Notifications</h1>
+
+    @if ($error)
+        <div class="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            {{ $error }}
+        </div>
+    @endif
+
+    @if ($notifications->isEmpty())
+        <p class="text-gray-500">You don't have any notifications yet.</p>
+    @else
+        <div class="space-y-3">
+            @foreach ($notifications as $notification)
+                <div
+                    wire:key="notification-{{ $notification->id }}"
+                    class="rounded-lg border bg-white p-4 {{ $notification->is_read ? 'border-gray-200' : 'border-green-200 bg-green-50/40' }}"
+                >
+                    <div class="flex items-start justify-between gap-4">
+                        <div>
+                            <div class="flex items-center gap-2">
+                                @unless ($notification->is_read)
+                                    <span class="h-2 w-2 shrink-0 rounded-full bg-green-600"></span>
+                                @endunless
+                                <div class="font-medium text-gray-900">{{ $notification->title }}</div>
+                            </div>
+                            <p class="mt-1 text-sm text-gray-600">{{ $notification->message }}</p>
+                        </div>
+
+                        <span class="shrink-0 text-xs text-gray-400">{{ $notification->created_at->diffForHumans() }}</span>
+                    </div>
+
+                    <div class="mt-4 flex items-center gap-3">
+                        @if ($notification->is_pending)
+                            <button
+                                type="button"
+                                wire:click="accept({{ $notification->id }})"
+                                wire:confirm="Accept this request?"
+                                class="text-green-700 hover:text-green-800"
+                            >
+                                Accept
+                            </button>
+                            <button
+                                type="button"
+                                wire:click="decline({{ $notification->id }})"
+                                wire:confirm="Decline this request?"
+                                class="text-red-600 hover:text-red-800"
+                            >
+                                Decline
+                            </button>
+                        @elseif (! $notification->is_read)
+                            <button
+                                type="button"
+                                wire:click="markRead({{ $notification->id }})"
+                                class="text-sm text-gray-500 hover:text-gray-700"
+                            >
+                                Mark as read
+                            </button>
+                        @endif
+                    </div>
+                </div>
+            @endforeach
+        </div>
+
+        {{ $notifications->links() }}
+    @endif
+</div>

--- a/resources/views/livewire/dashboard/profile-settings.blade.php
+++ b/resources/views/livewire/dashboard/profile-settings.blade.php
@@ -1,0 +1,108 @@
+<div class="max-w-2xl space-y-10">
+    <h1 class="text-2xl font-semibold text-gray-900">Profile & Settings</h1>
+
+    <section class="space-y-4 rounded-lg border border-gray-200 bg-white p-6">
+        <h2 class="text-lg font-semibold text-gray-900">Profile</h2>
+
+        @if ($statusMessage)
+            <div class="rounded-md bg-green-50 p-3 text-sm text-green-700">{{ $statusMessage }}</div>
+        @endif
+
+        <form wire:submit="updateProfile" class="space-y-4">
+            <div class="flex items-center gap-4">
+                <div class="h-16 w-16 shrink-0 overflow-hidden rounded-full bg-gray-100">
+                    @if ($avatar)
+                        <img src="{{ $avatar->temporaryUrl() }}" alt="Avatar preview" class="h-full w-full object-cover">
+                    @elseif (auth()->user()->avatar)
+                        <img src="{{ asset('storage/'.auth()->user()->avatar) }}" alt="Avatar" class="h-full w-full object-cover">
+                    @else
+                        <div class="flex h-full w-full items-center justify-center text-xs text-gray-400">No photo</div>
+                    @endif
+                </div>
+
+                <div>
+                    <label class="inline-block cursor-pointer rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                        Change photo
+                        <input wire:model="avatar" type="file" accept="image/*" class="hidden">
+                    </label>
+                    <div wire:loading wire:target="avatar" class="mt-1 text-xs text-gray-500">Uploading&hellip;</div>
+                    <x-input-error :messages="$errors->get('avatar')" class="mt-1" />
+                </div>
+            </div>
+
+            <div>
+                <x-input-label for="name" value="Name" />
+                <x-text-input wire:model="name" id="name" type="text" />
+                <x-input-error :messages="$errors->get('name')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="email" value="Email" />
+                <x-text-input wire:model="email" id="email" type="email" />
+                <x-input-error :messages="$errors->get('email')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="phone" value="Phone" />
+                <x-text-input wire:model="phone" id="phone" type="text" />
+                <x-input-error :messages="$errors->get('phone')" class="mt-2" />
+            </div>
+
+            <button type="submit" class="rounded-md bg-green-700 px-6 py-2 text-sm font-semibold text-white hover:bg-green-800">
+                Save changes
+            </button>
+        </form>
+    </section>
+
+    <section class="space-y-4 rounded-lg border border-gray-200 bg-white p-6">
+        <h2 class="text-lg font-semibold text-gray-900">Change password</h2>
+
+        @if ($passwordStatusMessage)
+            <div class="rounded-md bg-green-50 p-3 text-sm text-green-700">{{ $passwordStatusMessage }}</div>
+        @endif
+
+        <form wire:submit="updatePassword" class="space-y-4">
+            <div>
+                <x-input-label for="current_password" value="Current password" />
+                <x-text-input wire:model="current_password" id="current_password" type="password" autocomplete="current-password" />
+                <x-input-error :messages="$errors->get('current_password')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="password" value="New password" />
+                <x-text-input wire:model="password" id="password" type="password" autocomplete="new-password" />
+                <x-input-error :messages="$errors->get('password')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="password_confirmation" value="Confirm new password" />
+                <x-text-input wire:model="password_confirmation" id="password_confirmation" type="password" autocomplete="new-password" />
+                <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2" />
+            </div>
+
+            <button type="submit" class="rounded-md bg-green-700 px-6 py-2 text-sm font-semibold text-white hover:bg-green-800">
+                Update password
+            </button>
+        </form>
+    </section>
+
+    <section class="space-y-4 rounded-lg border border-red-200 bg-white p-6">
+        <h2 class="text-lg font-semibold text-red-700">Danger zone</h2>
+        <p class="text-sm text-gray-600">
+            Deleting your account is permanent. All of your properties, listings, and connections will remain associated
+            with your account record but you will no longer be able to log in.
+        </p>
+
+        <form wire:submit="deleteAccount" wire:confirm="Are you absolutely sure you want to delete your account? This cannot be undone." class="space-y-4">
+            <div class="max-w-sm">
+                <x-input-label for="delete_password" value="Confirm your password" />
+                <x-text-input wire:model="delete_password" id="delete_password" type="password" />
+                <x-input-error :messages="$errors->get('delete_password')" class="mt-2" />
+            </div>
+
+            <button type="submit" class="rounded-md bg-red-600 px-6 py-2 text-sm font-semibold text-white hover:bg-red-700">
+                Delete my account
+            </button>
+        </form>
+    </section>
+</div>

--- a/resources/views/livewire/dashboard/support-tickets.blade.php
+++ b/resources/views/livewire/dashboard/support-tickets.blade.php
@@ -1,0 +1,69 @@
+<div class="space-y-6">
+    <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold text-gray-900">Report a Problem</h1>
+
+        <button type="button" wire:click="$toggle('showForm')" class="rounded-md bg-green-700 px-4 py-2 text-sm font-semibold text-white hover:bg-green-800">
+            {{ $showForm ? 'Cancel' : 'New ticket' }}
+        </button>
+    </div>
+
+    @if ($showForm)
+        <form wire:submit="createTicket" class="space-y-4 rounded-lg border border-gray-200 bg-white p-6">
+            <div>
+                <x-input-label for="subject" value="Subject" />
+                <x-text-input wire:model="subject" id="subject" type="text" />
+                <x-input-error :messages="$errors->get('subject')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="message" value="Describe the problem" />
+                <textarea wire:model="message" id="message" rows="4" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500"></textarea>
+                <x-input-error :messages="$errors->get('message')" class="mt-2" />
+            </div>
+
+            <button type="submit" class="rounded-md bg-green-700 px-6 py-2 text-sm font-semibold text-white hover:bg-green-800">
+                Submit ticket
+            </button>
+        </form>
+    @endif
+
+    @if ($tickets->isEmpty())
+        <p class="text-gray-500">You haven't reported any problems yet.</p>
+    @else
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+            <table class="w-full text-left text-sm">
+                <thead class="border-b border-gray-200 bg-gray-50 text-gray-500">
+                    <tr>
+                        <th class="px-4 py-3">Subject</th>
+                        <th class="px-4 py-3">Status</th>
+                        <th class="px-4 py-3">Submitted</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    @foreach ($tickets as $ticket)
+                        <tr wire:key="ticket-{{ $ticket->id }}">
+                            <td class="px-4 py-3">
+                                <div class="font-medium text-gray-900">{{ $ticket->subject }}</div>
+                                <div class="text-gray-500">{{ \Illuminate\Support\Str::limit($ticket->message, 80) }}</div>
+                            </td>
+                            <td class="px-4 py-3">
+                                <span class="rounded-full px-2 py-0.5 text-xs font-medium {{ match ($ticket->status) {
+                                    'open' => 'bg-amber-50 text-amber-700',
+                                    'in_progress' => 'bg-blue-50 text-blue-700',
+                                    'resolved' => 'bg-green-50 text-green-700',
+                                    'closed' => 'bg-gray-100 text-gray-600',
+                                    default => 'bg-gray-100 text-gray-600',
+                                } }}">
+                                    {{ ucfirst(str_replace('_', ' ', $ticket->status)) }}
+                                </span>
+                            </td>
+                            <td class="px-4 py-3 text-gray-500">{{ $ticket->created_at->format('M j, Y') }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+
+        {{ $tickets->links() }}
+    @endif
+</div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -43,6 +43,7 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::prefix('connections')->group(function () {
     Route::get('/', [ConnectionController::class, 'index']); // connections aimed at my properties
+    Route::post('/', [ConnectionController::class, 'initiate']); // owner initiates a connection to an agency
     Route::post('/{id}/accept', [ConnectionController::class, 'accept']);
     Route::post('/{id}/reject', [ConnectionController::class, 'reject']);
     });
@@ -70,5 +71,7 @@ Route::prefix('agency')->middleware('agency.api_key')->group(function () {
     Route::prefix('connections')->group(function () {
     Route::get('/', [ConnectionController::class, 'indexForAgency']);
     Route::post('/', [ConnectionController::class, 'store']); // initiate a connection
+    Route::post('/{id}/accept', [ConnectionController::class, 'agencyAccept']); // respond to an owner-initiated request
+    Route::post('/{id}/reject', [ConnectionController::class, 'agencyReject']);
     });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,8 @@ Route::prefix('properties')->group(function () {
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('/profile', [AuthController::class, 'profile']);
+    Route::put('/profile', [AuthController::class, 'updateProfile']);
+    Route::delete('/profile', [AuthController::class, 'destroyAccount']);
     Route::post('/logout', [AuthController::class, 'logout']);
 
     Route::get('/my-properties', [PropertyController::class, 'mine']); // my own, any status

--- a/routes/api.php
+++ b/routes/api.php
@@ -39,6 +39,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/', [ListingController::class, 'index']); // listings on my properties
     Route::post('/{id}/approve', [ListingController::class, 'approve']);
     Route::post('/{id}/reject', [ListingController::class, 'reject']);
+    Route::post('/{id}/remove-agency', [ListingController::class, 'removeAgency']);
     });
 
     Route::prefix('connections')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Livewire\Dashboard\MyConnections;
 use App\Livewire\Dashboard\MyListings;
 use App\Livewire\Dashboard\MyProperties;
 use App\Livewire\Dashboard\PropertyForm;
+use App\Livewire\Dashboard\ProfileSettings;
 use App\Livewire\Public\Browse;
 use App\Livewire\Public\Home;
 use App\Livewire\Public\Show;
@@ -20,6 +21,7 @@ Route::middleware('auth')->prefix('dashboard')->name('dashboard.')->group(functi
     Route::get('/properties/{id}/edit', PropertyForm::class)->name('properties.edit');
     Route::get('/listings', MyListings::class)->name('listings.index');
     Route::get('/connections', MyConnections::class)->name('connections.index');
+    Route::get('/settings', ProfileSettings::class)->name('settings');
 });
 
 Route::get('/dashboard', Dashboard::class)

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Livewire\Dashboard;
 use App\Livewire\Dashboard\MyConnections;
 use App\Livewire\Dashboard\MyListings;
 use App\Livewire\Dashboard\MyProperties;
+use App\Livewire\Dashboard\Notifications;
 use App\Livewire\Dashboard\PropertyForm;
 use App\Livewire\Public\Browse;
 use App\Livewire\Public\Home;
@@ -20,6 +21,7 @@ Route::middleware('auth')->prefix('dashboard')->name('dashboard.')->group(functi
     Route::get('/properties/{id}/edit', PropertyForm::class)->name('properties.edit');
     Route::get('/listings', MyListings::class)->name('listings.index');
     Route::get('/connections', MyConnections::class)->name('connections.index');
+    Route::get('/notifications', Notifications::class)->name('notifications.index');
 });
 
 Route::get('/dashboard', Dashboard::class)

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Livewire\Dashboard\MyConnections;
 use App\Livewire\Dashboard\MyListings;
 use App\Livewire\Dashboard\MyProperties;
 use App\Livewire\Dashboard\PropertyForm;
+use App\Livewire\Dashboard\SupportTickets;
 use App\Livewire\Public\Browse;
 use App\Livewire\Public\Home;
 use App\Livewire\Public\Show;
@@ -20,6 +21,7 @@ Route::middleware('auth')->prefix('dashboard')->name('dashboard.')->group(functi
     Route::get('/properties/{id}/edit', PropertyForm::class)->name('properties.edit');
     Route::get('/listings', MyListings::class)->name('listings.index');
     Route::get('/connections', MyConnections::class)->name('connections.index');
+    Route::get('/support', SupportTickets::class)->name('support.index');
 });
 
 Route::get('/dashboard', Dashboard::class)

--- a/tests/Feature/ConnectionApiTest.php
+++ b/tests/Feature/ConnectionApiTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Models\Agency;
+use App\Models\AgencyApiKey;
 use App\Models\Connection;
+use App\Models\Notification;
 use App\Models\Property;
 use App\Models\User;
 use Laravel\Sanctum\Sanctum;
@@ -64,6 +67,33 @@ test('a past-expiry connection cannot be accepted and is marked expired', functi
     $this->postJson("/api/connections/{$connection->id}/accept")->assertStatus(409);
 
     expect($connection->fresh()->status)->toBe('expired');
+});
+
+test('an agency initiating a connection on a property notifies its owner', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id, 'title' => 'Cozy Cottage']);
+    $agency = Agency::factory()->create(['name' => 'Best Realtors']);
+    $apiKey = AgencyApiKey::factory()->create(['agency_id' => $agency->id]);
+
+    $response = $this->withHeader('X-Agency-Api-Key', $apiKey->api_key)
+        ->postJson('/api/agency/connections', ['property_id' => $property->id]);
+
+    $response->assertCreated();
+
+    $notification = Notification::where('user_id', $owner->id)->first();
+    expect($notification)->not->toBeNull();
+    expect($notification->payload)->toBe(['type' => 'connection_request', 'connection_id' => $response->json('id')]);
+});
+
+test('an agency initiating a connection to a phone number does not create a notification', function () {
+    $agency = Agency::factory()->create();
+    $apiKey = AgencyApiKey::factory()->create(['agency_id' => $agency->id]);
+
+    $this->withHeader('X-Agency-Api-Key', $apiKey->api_key)
+        ->postJson('/api/agency/connections', ['target_phone' => '555-0100'])
+        ->assertCreated();
+
+    expect(Notification::count())->toBe(0);
 });
 
 test('index only returns connections on the authenticated user\'s properties', function () {

--- a/tests/Feature/ConnectionApiTest.php
+++ b/tests/Feature/ConnectionApiTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Agency;
 use App\Models\Connection;
 use App\Models\Property;
 use App\Models\User;
@@ -82,4 +83,67 @@ test('index only returns connections on the authenticated user\'s properties', f
 
     $response->assertOk();
     expect($response->json('data'))->toHaveCount(1);
+});
+
+test('an owner can initiate a connection to an agency via the api', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    Sanctum::actingAs($owner);
+
+    $this->postJson('/api/connections', [
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'message' => 'Interested in listing.',
+    ])
+        ->assertCreated()
+        ->assertJsonPath('initiated_by', 'owner')
+        ->assertJsonPath('status', 'pending');
+});
+
+test('an owner cannot initiate a connection for a property they do not own via the api', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    Sanctum::actingAs($intruder);
+
+    $this->postJson('/api/connections', [
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+    ])->assertForbidden();
+});
+
+test('an agency can accept an owner-initiated connection via the api', function () {
+    $agency = Agency::factory()->create();
+    $apiKey = \App\Models\AgencyApiKey::factory()->create(['agency_id' => $agency->id]);
+    $property = Property::factory()->create();
+    $connection = Connection::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'initiated_by' => 'owner',
+    ]);
+
+    $this->withHeader('X-Agency-Api-Key', $apiKey->api_key)
+        ->postJson("/api/agency/connections/{$connection->id}/accept")
+        ->assertOk()
+        ->assertJsonPath('status', 'accepted');
+});
+
+test('an agency cannot accept another agency\'s owner-initiated connection via the api', function () {
+    $agency = Agency::factory()->create();
+    $intruderAgency = Agency::factory()->create();
+    $apiKey = \App\Models\AgencyApiKey::factory()->create(['agency_id' => $intruderAgency->id]);
+    $property = Property::factory()->create();
+    $connection = Connection::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'initiated_by' => 'owner',
+    ]);
+
+    $this->withHeader('X-Agency-Api-Key', $apiKey->api_key)
+        ->postJson("/api/agency/connections/{$connection->id}/accept")
+        ->assertForbidden();
 });

--- a/tests/Feature/ConnectionServiceTest.php
+++ b/tests/Feature/ConnectionServiceTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Exceptions\ConnectionActionException;
+use App\Models\Agency;
 use App\Models\Connection;
 use App\Models\Property;
 use App\Models\User;
@@ -85,4 +86,108 @@ test('mine() only returns connections on the given user\'s properties', function
     Connection::factory()->create(['property_id' => $otherProperty->id]);
 
     expect(app(ConnectionService::class)->mine($owner)->count())->toBe(1);
+});
+
+test('mine() excludes owner-initiated connections', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+
+    Connection::factory()->create(['property_id' => $property->id, 'initiated_by' => 'owner']);
+    Connection::factory()->create(['property_id' => $property->id, 'initiated_by' => 'agency']);
+
+    expect(app(ConnectionService::class)->mine($owner)->count())->toBe(1);
+});
+
+test('sentByMe() only returns owner-initiated connections on the given user\'s properties', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+
+    $ownProperty = Property::factory()->create(['user_id' => $owner->id]);
+    $otherProperty = Property::factory()->create(['user_id' => $other->id]);
+
+    Connection::factory()->create(['property_id' => $ownProperty->id, 'initiated_by' => 'owner']);
+    Connection::factory()->create(['property_id' => $ownProperty->id, 'initiated_by' => 'agency']);
+    Connection::factory()->create(['property_id' => $otherProperty->id, 'initiated_by' => 'owner']);
+
+    expect(app(ConnectionService::class)->sentByMe($owner)->count())->toBe(1);
+});
+
+test('an owner can initiate a connection to an agency', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    $connection = app(ConnectionService::class)->initiate($owner, $property, $agency, 'Interested in listing.');
+
+    expect($connection->status)->toBe('pending');
+    expect($connection->initiated_by)->toBe('owner');
+    expect($connection->agency_id)->toBe($agency->id);
+});
+
+test('an owner cannot initiate a connection for a property they do not own', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    expect(fn () => app(ConnectionService::class)->initiate($intruder, $property, $agency, null))
+        ->toThrow(ConnectionActionException::class);
+});
+
+test('an agency can accept an owner-initiated connection', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+    $connection = Connection::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'initiated_by' => 'owner',
+    ]);
+
+    $result = app(ConnectionService::class)->acceptAsAgency($connection, $agency);
+
+    expect($result->status)->toBe('accepted');
+});
+
+test('an agency can reject an owner-initiated connection', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+    $connection = Connection::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'initiated_by' => 'owner',
+    ]);
+
+    $result = app(ConnectionService::class)->rejectAsAgency($connection, $agency);
+
+    expect($result->status)->toBe('rejected');
+});
+
+test('a different agency cannot respond to an owner-initiated connection', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+    $intruderAgency = Agency::factory()->create();
+    $connection = Connection::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'initiated_by' => 'owner',
+    ]);
+
+    expect(fn () => app(ConnectionService::class)->acceptAsAgency($connection, $intruderAgency))
+        ->toThrow(ConnectionActionException::class);
+});
+
+test('an agency cannot respond to its own agency-initiated connection via the agency-response methods', function () {
+    $agency = Agency::factory()->create();
+    $property = Property::factory()->create();
+    $connection = Connection::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'initiated_by' => 'agency',
+    ]);
+
+    expect(fn () => app(ConnectionService::class)->acceptAsAgency($connection, $agency))
+        ->toThrow(ConnectionActionException::class);
 });

--- a/tests/Feature/Dashboard/MyConnectionsTest.php
+++ b/tests/Feature/Dashboard/MyConnectionsTest.php
@@ -103,3 +103,77 @@ test('agency name and message are shown for each connection', function () {
         ->assertSee('Best Realtors')
         ->assertSee('We would love to list this property.');
 });
+
+test('an owner-initiated connection does not appear on the received tab', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id, 'title' => 'My House']);
+    Connection::factory()->create(['property_id' => $property->id, 'initiated_by' => 'owner']);
+
+    Livewire::actingAs($owner)
+        ->test(MyConnections::class)
+        ->set('tab', 'received')
+        ->assertDontSee('My House');
+});
+
+test('the sent tab only shows connections the owner initiated', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create(['name' => 'Best Realtors']);
+    Connection::factory()->create(['property_id' => $property->id, 'agency_id' => $agency->id, 'initiated_by' => 'owner']);
+    Connection::factory()->create(['property_id' => $property->id, 'initiated_by' => 'agency']);
+
+    $component = Livewire::actingAs($owner)
+        ->test(MyConnections::class)
+        ->set('tab', 'sent');
+
+    expect($component->viewData('connections'))->toHaveCount(1);
+    $component->assertSee('Best Realtors');
+});
+
+test('a sent connection has no accept/reject buttons', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    Connection::factory()->create(['property_id' => $property->id, 'initiated_by' => 'owner']);
+
+    Livewire::actingAs($owner)
+        ->test(MyConnections::class)
+        ->set('tab', 'sent')
+        ->assertDontSee('Accept')
+        ->assertDontSee('Reject');
+});
+
+test('an owner can send a connection request to an agency', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    Livewire::actingAs($owner)
+        ->test(MyConnections::class)
+        ->set('property_id', (string) $property->id)
+        ->set('agency_id', (string) $agency->id)
+        ->set('message', 'Interested in listing this property.')
+        ->call('sendRequest')
+        ->assertSet('tab', 'sent');
+
+    expect(Connection::where('property_id', $property->id)
+        ->where('agency_id', $agency->id)
+        ->where('initiated_by', 'owner')
+        ->exists())->toBeTrue();
+});
+
+test('an owner cannot send a connection request for a property they do not own', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    $this->actingAs($intruder);
+
+    expect(fn () => Livewire::test(MyConnections::class)
+        ->set('property_id', (string) $property->id)
+        ->set('agency_id', (string) $agency->id)
+        ->call('sendRequest'))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    expect(Connection::where('property_id', $property->id)->exists())->toBeFalse();
+});

--- a/tests/Feature/Dashboard/MyListingsTest.php
+++ b/tests/Feature/Dashboard/MyListingsTest.php
@@ -100,3 +100,47 @@ test('agency name is shown for each listing', function () {
         ->test(MyListings::class)
         ->assertSee('Best Realtors');
 });
+
+test('an approved listing shows a Remove Agency button', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(MyListings::class)
+        ->assertSee('Remove Agency');
+});
+
+test('owner can remove the agency from an approved listing', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(MyListings::class)
+        ->call('removeAgency', $listing->id);
+
+    expect($listing->fresh()->status)->toBe('archived');
+});
+
+test('an archived listing does not show a Remove Agency button', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'archived',
+        'user_approved' => false,
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(MyListings::class)
+        ->assertDontSee('Remove Agency');
+});

--- a/tests/Feature/Dashboard/NotificationsTest.php
+++ b/tests/Feature/Dashboard/NotificationsTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use App\Livewire\Dashboard\Notifications;
+use App\Models\Connection;
+use App\Models\Listing;
+use App\Models\Notification;
+use App\Models\Property;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('guests are redirected to login', function () {
+    $this->get(route('dashboard.notifications.index'))->assertRedirect(route('login'));
+});
+
+test('only the authenticated user\'s own notifications are listed', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    Notification::factory()->create(['user_id' => $user->id, 'title' => 'My notification']);
+    Notification::factory()->create(['user_id' => $other->id, 'title' => 'Their notification']);
+
+    Livewire::actingAs($user)
+        ->test(Notifications::class)
+        ->assertSee('My notification')
+        ->assertDontSee('Their notification');
+});
+
+test('a listing_proposed notification for a still-pending listing shows accept/decline', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+    Notification::factory()->create([
+        'user_id' => $owner->id,
+        'payload' => ['type' => 'listing_proposed', 'listing_id' => $listing->id],
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(Notifications::class)
+        ->assertSee('Accept')
+        ->assertSee('Decline');
+});
+
+test('accepting a listing_proposed notification approves the listing and marks it read', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+    $notification = Notification::factory()->create([
+        'user_id' => $owner->id,
+        'payload' => ['type' => 'listing_proposed', 'listing_id' => $listing->id],
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(Notifications::class)
+        ->call('accept', $notification->id);
+
+    expect($listing->fresh()->status)->toBe('available');
+    expect($notification->fresh()->is_read)->toBeTrue();
+});
+
+test('declining a connection_request notification rejects the connection', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $connection = Connection::factory()->create(['property_id' => $property->id]);
+    $notification = Notification::factory()->create([
+        'user_id' => $owner->id,
+        'payload' => ['type' => 'connection_request', 'connection_id' => $connection->id],
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(Notifications::class)
+        ->call('decline', $notification->id);
+
+    expect($connection->fresh()->status)->toBe('rejected');
+    expect($notification->fresh()->is_read)->toBeTrue();
+});
+
+test('acting on an already-resolved notification shows an error', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+    $notification = Notification::factory()->create([
+        'user_id' => $owner->id,
+        'payload' => ['type' => 'listing_proposed', 'listing_id' => $listing->id],
+    ]);
+
+    $component = Livewire::actingAs($owner)->test(Notifications::class);
+    $component->call('accept', $notification->id);
+    $component->call('decline', $notification->id);
+
+    expect($component->get('error'))->not->toBeNull();
+});
+
+test('a resolved listing_proposed notification no longer shows accept/decline', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+    Notification::factory()->create([
+        'user_id' => $owner->id,
+        'payload' => ['type' => 'listing_proposed', 'listing_id' => $listing->id],
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(Notifications::class)
+        ->assertDontSee('Accept')
+        ->assertDontSee('Decline');
+});
+
+test('a non-actionable notification can be marked as read', function () {
+    $user = User::factory()->create();
+    $notification = Notification::factory()->create(['user_id' => $user->id]);
+
+    Livewire::actingAs($user)
+        ->test(Notifications::class)
+        ->assertSee('Mark as read')
+        ->call('markRead', $notification->id);
+
+    expect($notification->fresh()->is_read)->toBeTrue();
+});
+
+test('a user cannot mark another user\'s notification as read', function () {
+    $user = User::factory()->create();
+    $intruder = User::factory()->create();
+    $notification = Notification::factory()->create(['user_id' => $user->id]);
+
+    $this->actingAs($intruder);
+
+    expect(fn () => Livewire::test(Notifications::class)->call('markRead', $notification->id))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+});

--- a/tests/Feature/Dashboard/ProfileSettingsTest.php
+++ b/tests/Feature/Dashboard/ProfileSettingsTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use App\Livewire\Dashboard\ProfileSettings;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+
+test('guests are redirected to login', function () {
+    $this->get(route('dashboard.settings'))->assertRedirect(route('login'));
+});
+
+test('mount fills in the current user\'s details', function () {
+    $user = User::factory()->create(['name' => 'Jane Doe', 'email' => 'jane@example.com', 'phone' => '5551234']);
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->assertSet('name', 'Jane Doe')
+        ->assertSet('email', 'jane@example.com')
+        ->assertSet('phone', '5551234');
+});
+
+test('a user can update their name, email, and phone', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->set('name', 'Updated Name')
+        ->set('email', 'updated@example.com')
+        ->set('phone', '9998887777')
+        ->call('updateProfile')
+        ->assertSet('statusMessage', 'Profile updated.');
+
+    expect($user->fresh())
+        ->name->toBe('Updated Name')
+        ->email->toBe('updated@example.com')
+        ->phone->toBe('9998887777');
+});
+
+test('email must be unique among other users', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create(['email' => 'taken@example.com']);
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->set('email', 'taken@example.com')
+        ->call('updateProfile')
+        ->assertHasErrors(['email']);
+});
+
+test('a user can upload a new avatar and the old one is deleted', function () {
+    Storage::fake('public');
+    $user = User::factory()->create(['avatar' => 'avatars/old.jpg']);
+    Storage::disk('public')->put('avatars/old.jpg', 'fake-content');
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->set('avatar', UploadedFile::fake()->image('new.jpg'))
+        ->call('updateProfile');
+
+    Storage::disk('public')->assertMissing('avatars/old.jpg');
+    expect($user->fresh()->avatar)->not->toBeNull();
+});
+
+test('a user can update their password with the correct current password', function () {
+    $user = User::factory()->create(['password' => Hash::make('old-password')]);
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->set('current_password', 'old-password')
+        ->set('password', 'new-password')
+        ->set('password_confirmation', 'new-password')
+        ->call('updatePassword')
+        ->assertSet('passwordStatusMessage', 'Password updated.');
+
+    expect(Hash::check('new-password', $user->fresh()->password))->toBeTrue();
+});
+
+test('updating the password fails with an incorrect current password', function () {
+    $user = User::factory()->create(['password' => Hash::make('old-password')]);
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->set('current_password', 'wrong-password')
+        ->set('password', 'new-password')
+        ->set('password_confirmation', 'new-password')
+        ->call('updatePassword')
+        ->assertHasErrors(['current_password']);
+
+    expect(Hash::check('old-password', $user->fresh()->password))->toBeTrue();
+});
+
+test('a user can delete their account with the correct password', function () {
+    $user = User::factory()->create(['password' => Hash::make('correct-password')]);
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->set('delete_password', 'correct-password')
+        ->call('deleteAccount')
+        ->assertRedirect(route('home'));
+
+    expect(User::find($user->id))->toBeNull();
+    expect(User::withTrashed()->find($user->id)->trashed())->toBeTrue();
+});
+
+test('deleting the account fails with an incorrect password and the account is kept', function () {
+    $user = User::factory()->create(['password' => Hash::make('correct-password')]);
+
+    Livewire::actingAs($user)
+        ->test(ProfileSettings::class)
+        ->set('delete_password', 'wrong-password')
+        ->call('deleteAccount')
+        ->assertHasErrors(['delete_password']);
+
+    expect($user->fresh())->not->toBeNull();
+});

--- a/tests/Feature/Dashboard/SupportTicketsTest.php
+++ b/tests/Feature/Dashboard/SupportTicketsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Livewire\Dashboard\SupportTickets;
+use App\Models\SupportTicket;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('guests are redirected to login', function () {
+    $this->get(route('dashboard.support.index'))->assertRedirect(route('login'));
+});
+
+test('only the authenticated user\'s own tickets are listed', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    SupportTicket::factory()->create(['user_id' => $user->id, 'subject' => 'My problem']);
+    SupportTicket::factory()->create(['user_id' => $other->id, 'subject' => 'Their problem']);
+
+    Livewire::actingAs($user)
+        ->test(SupportTickets::class)
+        ->assertSee('My problem')
+        ->assertDontSee('Their problem');
+});
+
+test('a user can create a support ticket', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(SupportTickets::class)
+        ->set('subject', 'App keeps crashing')
+        ->set('message', 'It crashes every time I open the listings page.')
+        ->call('createTicket')
+        ->assertSet('showForm', false);
+
+    expect(SupportTicket::where('user_id', $user->id)->where('subject', 'App keeps crashing')->exists())->toBeTrue();
+});
+
+test('subject and message are required', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(SupportTickets::class)
+        ->set('subject', '')
+        ->set('message', '')
+        ->call('createTicket')
+        ->assertHasErrors(['subject', 'message']);
+});
+
+test('ticket status is shown', function () {
+    $user = User::factory()->create();
+    SupportTicket::factory()->create(['user_id' => $user->id, 'status' => 'resolved']);
+
+    Livewire::actingAs($user)
+        ->test(SupportTickets::class)
+        ->assertSee('Resolved');
+});

--- a/tests/Feature/ListingApiTest.php
+++ b/tests/Feature/ListingApiTest.php
@@ -53,6 +53,47 @@ test('approving an already-responded listing conflicts', function () {
     $this->postJson("/api/listings/{$listing->id}/reject")->assertStatus(409);
 });
 
+test('owner can remove the agency from an approved listing via the api', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+
+    Sanctum::actingAs($owner);
+
+    $this->postJson("/api/listings/{$listing->id}/remove-agency")
+        ->assertOk()
+        ->assertJsonPath('status', 'archived');
+});
+
+test('a non-owner cannot remove the agency from a listing via the api', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+
+    Sanctum::actingAs($intruder);
+
+    $this->postJson("/api/listings/{$listing->id}/remove-agency")->assertForbidden();
+});
+
+test('removing the agency from a listing that was never approved conflicts via the api', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    Sanctum::actingAs($owner);
+
+    $this->postJson("/api/listings/{$listing->id}/remove-agency")->assertStatus(409);
+});
+
 test('index only returns listings on the authenticated user\'s properties', function () {
     $owner = User::factory()->create();
     $other = User::factory()->create();

--- a/tests/Feature/ListingServiceTest.php
+++ b/tests/Feature/ListingServiceTest.php
@@ -51,6 +51,61 @@ test('a listing that has already been responded to cannot be responded to again'
         ->toThrow(ListingActionException::class);
 });
 
+test('owner can remove the agency from an approved listing', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+
+    $result = app(ListingService::class)->removeAgency($listing, $owner);
+
+    expect($result->status)->toBe('archived');
+    expect($listing->statusHistories()->count())->toBe(1);
+});
+
+test('a non-owner cannot remove the agency from a listing', function () {
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+
+    expect(fn () => app(ListingService::class)->removeAgency($listing, $intruder))
+        ->toThrow(ListingActionException::class);
+});
+
+test('the agency cannot be removed from a listing that was never approved', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create(['property_id' => $property->id]);
+
+    expect(fn () => app(ListingService::class)->removeAgency($listing, $owner))
+        ->toThrow(ListingActionException::class);
+
+    expect($listing->fresh()->status)->toBe('pending');
+});
+
+test('the agency cannot be removed twice from an already-archived listing', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $listing = Listing::factory()->create([
+        'property_id' => $property->id,
+        'status' => 'available',
+        'user_approved' => true,
+    ]);
+
+    app(ListingService::class)->removeAgency($listing, $owner);
+
+    expect(fn () => app(ListingService::class)->removeAgency($listing->fresh(), $owner))
+        ->toThrow(ListingActionException::class);
+});
+
 test('mine() only returns listings on the given user\'s properties', function () {
     $owner = User::factory()->create();
     $other = User::factory()->create();

--- a/tests/Feature/ListingServiceTest.php
+++ b/tests/Feature/ListingServiceTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Exceptions\ListingActionException;
+use App\Models\Agency;
 use App\Models\Listing;
+use App\Models\Notification;
 use App\Models\Property;
 use App\Models\User;
 use App\Services\ListingService;
@@ -49,6 +51,20 @@ test('a listing that has already been responded to cannot be responded to again'
 
     expect(fn () => app(ListingService::class)->reject($listing->fresh(), $owner))
         ->toThrow(ListingActionException::class);
+});
+
+test('proposing a listing notifies the property owner', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id, 'title' => 'Cozy Cottage']);
+    $agency = Agency::factory()->create(['name' => 'Best Realtors']);
+
+    $listing = app(ListingService::class)->propose($agency, $property->id);
+
+    $notification = Notification::where('user_id', $owner->id)->first();
+
+    expect($notification)->not->toBeNull();
+    expect($notification->payload)->toBe(['type' => 'listing_proposed', 'listing_id' => $listing->id]);
+    expect($notification->message)->toContain('Best Realtors')->toContain('Cozy Cottage');
 });
 
 test('mine() only returns listings on the given user\'s properties', function () {

--- a/tests/Feature/ProfileApiTest.php
+++ b/tests/Feature/ProfileApiTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Sanctum\Sanctum;
+
+test('a user can update their profile via the api', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user);
+
+    $this->putJson('/api/profile', ['name' => 'New Name'])
+        ->assertOk()
+        ->assertJsonPath('name', 'New Name');
+
+    expect($user->fresh()->name)->toBe('New Name');
+});
+
+test('a user can upload an avatar via the api', function () {
+    Storage::fake('public');
+    $user = User::factory()->create();
+    Sanctum::actingAs($user);
+
+    $this->putJson('/api/profile', ['avatar' => UploadedFile::fake()->image('avatar.jpg')])
+        ->assertOk();
+
+    expect($user->fresh()->avatar)->not->toBeNull();
+});
+
+test('email must be unique when updating profile via the api', function () {
+    $user = User::factory()->create();
+    User::factory()->create(['email' => 'taken@example.com']);
+    Sanctum::actingAs($user);
+
+    $this->putJson('/api/profile', ['email' => 'taken@example.com'])
+        ->assertStatus(422);
+});
+
+test('a user can delete their account via the api with the correct password', function () {
+    $user = User::factory()->create(['password' => Hash::make('correct-password')]);
+    Sanctum::actingAs($user);
+
+    $this->deleteJson('/api/profile', ['password' => 'correct-password'])
+        ->assertOk();
+
+    expect(User::find($user->id))->toBeNull();
+    expect(User::withTrashed()->find($user->id)->trashed())->toBeTrue();
+});
+
+test('deleting an account via the api fails with an incorrect password', function () {
+    $user = User::factory()->create(['password' => Hash::make('correct-password')]);
+    Sanctum::actingAs($user);
+
+    $this->deleteJson('/api/profile', ['password' => 'wrong-password'])
+        ->assertStatus(422);
+
+    expect($user->fresh())->not->toBeNull();
+});

--- a/tests/Feature/ProfileApiTest.php
+++ b/tests/Feature/ProfileApiTest.php
@@ -28,6 +28,44 @@ test('a user can upload an avatar via the api', function () {
     expect($user->fresh()->avatar)->not->toBeNull();
 });
 
+test('a user can change their password via the api with the correct current password', function () {
+    $user = User::factory()->create(['password' => Hash::make('old-password')]);
+    Sanctum::actingAs($user);
+
+    $this->putJson('/api/profile', [
+        'current_password' => 'old-password',
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ])->assertOk();
+
+    expect(Hash::check('new-password', $user->fresh()->password))->toBeTrue();
+});
+
+test('changing the password via the api fails without the correct current password', function () {
+    $user = User::factory()->create(['password' => Hash::make('old-password')]);
+    Sanctum::actingAs($user);
+
+    $this->putJson('/api/profile', [
+        'current_password' => 'wrong-password',
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ])->assertStatus(422);
+
+    expect(Hash::check('old-password', $user->fresh()->password))->toBeTrue();
+});
+
+test('changing the password via the api fails without current_password at all', function () {
+    $user = User::factory()->create(['password' => Hash::make('old-password')]);
+    Sanctum::actingAs($user);
+
+    $this->putJson('/api/profile', [
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ])->assertStatus(422);
+
+    expect(Hash::check('old-password', $user->fresh()->password))->toBeTrue();
+});
+
 test('email must be unique when updating profile via the api', function () {
     $user = User::factory()->create();
     User::factory()->create(['email' => 'taken@example.com']);


### PR DESCRIPTION
## Summary
Periodic sync of develop into main. Brings in the five reviewed and merged feature batches:

- Profile settings, complete-profile nudge, delete account, logout confirmation (1.8, 1.18, 1.20, 1.21) — includes a post-review fix requiring current_password before an API password change
- Support Tickets dashboard (1.19)
- Owner-initiated Connections (1.9/1.15)
- Remove Agency from an approved Listing (1.10/1.16)
- Notifications with actionable cards (1.22/1.23/1.24)

All changes were reviewed via /review and merged into develop individually; full test suite (140 tests) passes on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)