### PR TITLE
Harden connections: block duplicate requests, catch agency-action races

### DIFF
--- a/app/Filament/Agency/Resources/ConnectionResource.php
+++ b/app/Filament/Agency/Resources/ConnectionResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Agency\Resources;
 
+use App\Exceptions\ConnectionActionException;
 use App\Filament\Agency\Resources\ConnectionResource\Pages;
 use App\Models\Connection;
 use App\Models\Property;
@@ -111,7 +112,13 @@ class ConnectionResource extends Resource
                     ->requiresConfirmation()
                     ->color('success')
                     ->action(function (Connection $record) {
-                        app(ConnectionService::class)->acceptAsAgency($record, Filament::auth()->user());
+                        try {
+                            app(ConnectionService::class)->acceptAsAgency($record, Filament::auth()->user());
+                        } catch (ConnectionActionException $e) {
+                            Notification::make()->title($e->getMessage())->warning()->send();
+
+                            return;
+                        }
 
                         Notification::make()->title('Connection accepted')->success()->send();
                     }),
@@ -120,7 +127,13 @@ class ConnectionResource extends Resource
                     ->requiresConfirmation()
                     ->color('danger')
                     ->action(function (Connection $record) {
-                        app(ConnectionService::class)->rejectAsAgency($record, Filament::auth()->user());
+                        try {
+                            app(ConnectionService::class)->rejectAsAgency($record, Filament::auth()->user());
+                        } catch (ConnectionActionException $e) {
+                            Notification::make()->title($e->getMessage())->warning()->send();
+
+                            return;
+                        }
 
                         Notification::make()->title('Connection rejected')->success()->send();
                     }),

--- a/app/Services/ConnectionService.php
+++ b/app/Services/ConnectionService.php
@@ -42,6 +42,19 @@ class ConnectionService
             throw new ConnectionActionException('You do not own this property.', 403);
         }
 
+        $exists = Connection::where('property_id', $property->id)
+            ->where('agency_id', $agency->id)
+            ->where('initiated_by', 'owner')
+            ->where('status', 'pending')
+            ->exists();
+
+        if ($exists) {
+            throw new ConnectionActionException(
+                'You already have a pending connection request to this agency for this property.',
+                409
+            );
+        }
+
         return Connection::create([
             'agency_id' => $agency->id,
             'property_id' => $property->id,

--- a/tests/Feature/ConnectionApiTest.php
+++ b/tests/Feature/ConnectionApiTest.php
@@ -145,6 +145,24 @@ test('an owner cannot initiate a connection for a property they do not own via t
     ])->assertForbidden();
 });
 
+test('an owner cannot initiate a duplicate pending connection via the api', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    Sanctum::actingAs($owner);
+
+    $this->postJson('/api/connections', [
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+    ])->assertCreated();
+
+    $this->postJson('/api/connections', [
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+    ])->assertStatus(409);
+});
+
 test('an agency can accept an owner-initiated connection via the api', function () {
     $agency = Agency::factory()->create();
     $apiKey = \App\Models\AgencyApiKey::factory()->create(['agency_id' => $agency->id]);

--- a/tests/Feature/ConnectionServiceTest.php
+++ b/tests/Feature/ConnectionServiceTest.php
@@ -134,6 +134,44 @@ test('an owner cannot initiate a connection for a property they do not own', fun
         ->toThrow(ConnectionActionException::class);
 });
 
+test('an owner cannot initiate a second pending connection to the same agency for the same property', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    app(ConnectionService::class)->initiate($owner, $property, $agency, 'First request.');
+
+    expect(fn () => app(ConnectionService::class)->initiate($owner, $property, $agency, 'Second request.'))
+        ->toThrow(ConnectionActionException::class);
+
+    expect(Connection::where('property_id', $property->id)->where('agency_id', $agency->id)->count())->toBe(1);
+});
+
+test('an owner can re-initiate a connection to the same agency once the earlier request is no longer pending', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    $first = app(ConnectionService::class)->initiate($owner, $property, $agency, 'First request.');
+    app(ConnectionService::class)->acceptAsAgency($first, $agency);
+
+    $second = app(ConnectionService::class)->initiate($owner, $property, $agency, 'Second request.');
+
+    expect($second->status)->toBe('pending');
+});
+
+test('an owner can send a pending connection to a different agency for the same property', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+    $otherAgency = Agency::factory()->create();
+
+    app(ConnectionService::class)->initiate($owner, $property, $agency, 'To agency one.');
+    $second = app(ConnectionService::class)->initiate($owner, $property, $otherAgency, 'To agency two.');
+
+    expect($second->status)->toBe('pending');
+});
+
 test('an agency can accept an owner-initiated connection', function () {
     $owner = User::factory()->create();
     $property = Property::factory()->create(['user_id' => $owner->id]);

--- a/tests/Feature/Dashboard/MyConnectionsTest.php
+++ b/tests/Feature/Dashboard/MyConnectionsTest.php
@@ -161,6 +161,28 @@ test('an owner can send a connection request to an agency', function () {
         ->exists())->toBeTrue();
 });
 
+test('an owner cannot send a duplicate pending connection request to the same agency', function () {
+    $owner = User::factory()->create();
+    $property = Property::factory()->create(['user_id' => $owner->id]);
+    $agency = Agency::factory()->create();
+
+    Connection::factory()->create([
+        'property_id' => $property->id,
+        'agency_id' => $agency->id,
+        'initiated_by' => 'owner',
+        'status' => 'pending',
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(MyConnections::class)
+        ->set('property_id', (string) $property->id)
+        ->set('agency_id', (string) $agency->id)
+        ->call('sendRequest')
+        ->assertSet('formError', 'You already have a pending connection request to this agency for this property.');
+
+    expect(Connection::where('property_id', $property->id)->where('agency_id', $agency->id)->count())->toBe(1);
+});
+
 test('an owner cannot send a connection request for a property they do not own', function () {
     $owner = User::factory()->create();
     $intruder = User::factory()->create();


### PR DESCRIPTION
## Summary
Two follow-ups flagged during the PR #41 review, tracked as tasks and addressed now:

- `ConnectionService::initiate()` now blocks an owner from sending a second pending request to the same agency for the same property (mirrors the duplicate-check already present in `ListingService::propose()`), while still allowing a fresh request once the earlier one is resolved (accepted/rejected/expired).
- The Agency Filament panel's Accept/Reject table actions now catch `ConnectionActionException` and show a warning notification instead of surfacing a raw error page — covers the case where a connection gets resolved elsewhere between page load and click.

## Test plan
- [x] `php artisan test` — full suite passes (145 tests)
- [x] New tests: `ConnectionServiceTest` (duplicate-block, re-initiate-after-resolved, different-agency-allowed), `ConnectionApiTest` (duplicate via API), `Dashboard/MyConnectionsTest` (duplicate via the web form)
- [x] Verified live: logged into the Agency panel, accepted an owner-initiated connection through the UI (confirmation modal → success notification, status updated correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)